### PR TITLE
Optimize

### DIFF
--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1547,7 +1547,7 @@ OPJ_FLOAT64 opj_clock(void) {
 	/* cout << "freq = " << ((double) freq.QuadPart) << endl; */
     /* t is the high resolution performance counter (see MSDN) */
     QueryPerformanceCounter ( & t ) ;
-    return ( t.QuadPart /(OPJ_FLOAT64) freq.QuadPart ) ;
+    return freq.QuadPart ? ( t.QuadPart /(OPJ_FLOAT64) freq.QuadPart ) : 0 ;
 #else
 	/* Unix or Linux: use resource usage */
     struct rusage t;
@@ -1871,8 +1871,9 @@ int main(int argc, char **argv) {
     if(raw_cp.rawComps) free(raw_cp.rawComps);
 	
 	t = opj_clock() - t;
-	fprintf(stdout, "encode time: %d ms \n", (int)((t * 1000)/num_compressed_files));
-	scanf("%d");
+	if (num_compressed_files)
+		fprintf(stdout, "encode time: %d ms \n", (int)((t * 1000)/num_compressed_files));
+	//getch());
 
     return 0;
 }

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -57,6 +57,9 @@
 #define strncasecmp _strnicmp
 #else
 #include <strings.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/times.h>
 #endif /* _WIN32 */
 
 #include "opj_apps_config.h"
@@ -1535,6 +1538,31 @@ static void info_callback(const char *msg, void *client_data) {
     fprintf(stdout, "[INFO] %s", msg);
 }
 
+OPJ_FLOAT64 opj_clock(void) {
+#ifdef _WIN32
+	/* _WIN32: use QueryPerformance (very accurate) */
+    LARGE_INTEGER freq , t ;
+    /* freq is the clock speed of the CPU */
+    QueryPerformanceFrequency(&freq) ;
+	/* cout << "freq = " << ((double) freq.QuadPart) << endl; */
+    /* t is the high resolution performance counter (see MSDN) */
+    QueryPerformanceCounter ( & t ) ;
+    return ( t.QuadPart /(OPJ_FLOAT64) freq.QuadPart ) ;
+#else
+	/* Unix or Linux: use resource usage */
+    struct rusage t;
+    OPJ_FLOAT64 procTime;
+    /* (1) Get the rusage data structure at this moment (man getrusage) */
+    getrusage(0,&t);
+    /* (2) What is the elapsed time ? - CPU time = User time + System time */
+	/* (2a) Get the seconds */
+    procTime = (OPJ_FLOAT64)(t.ru_utime.tv_sec + t.ru_stime.tv_sec);
+    /* (2b) More precisely! Get the microseconds part ! */
+    return ( procTime + (OPJ_FLOAT64)(t.ru_utime.tv_usec + t.ru_stime.tv_usec) * 1e-6 ) ;
+#endif
+}
+
+
 /* -------------------------------------------------------------------------- */
 /**
  * OPJ_COMPRESS MAIN
@@ -1548,6 +1576,7 @@ int main(int argc, char **argv) {
     opj_codec_t* l_codec = 00;
     opj_image_t *image = NULL;
     raw_cparameters_t raw_cp;
+	OPJ_SIZE_T num_compressed_files = 0;
 
     char indexfilename[OPJ_PATH_LEN];	/* index file name */
 
@@ -1558,6 +1587,7 @@ int main(int argc, char **argv) {
     OPJ_BOOL bSuccess;
     OPJ_BOOL bUseTiles = OPJ_FALSE; /* OPJ_TRUE */
     OPJ_UINT32 l_nb_tiles = 4;
+	OPJ_FLOAT64 t = opj_clock();
 
     /* set encoding parameters to default values */
     opj_set_default_encoder_parameters(&parameters);
@@ -1822,6 +1852,7 @@ int main(int argc, char **argv) {
             return 1;
         }
 
+		num_compressed_files++;
         fprintf(stdout,"[INFO] Generated outfile %s\n",parameters.outfile);
         /* close and free the byte stream */
         opj_stream_destroy(l_stream);
@@ -1838,6 +1869,10 @@ int main(int argc, char **argv) {
     if(parameters.cp_comment)   free(parameters.cp_comment);
     if(parameters.cp_matrice)   free(parameters.cp_matrice);
     if(raw_cp.rawComps) free(raw_cp.rawComps);
+	
+	t = opj_clock() - t;
+	fprintf(stdout, "encode time: %d ms \n", (int)((t * 1000)/num_compressed_files));
+	scanf("%d");
 
     return 0;
 }

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -852,7 +852,7 @@ OPJ_FLOAT64 opj_clock(void) {
 	/* cout << "freq = " << ((double) freq.QuadPart) << endl; */
     /* t is the high resolution performance counter (see MSDN) */
     QueryPerformanceCounter ( & t ) ;
-    return ( t.QuadPart /(OPJ_FLOAT64) freq.QuadPart ) ;
+	return freq.QuadPart ? (t.QuadPart / (OPJ_FLOAT64)freq.QuadPart) : 0;
 #else
 	/* Unix or Linux: use resource usage */
     struct rusage t;
@@ -1535,8 +1535,9 @@ int main(int argc, char **argv)
 		if(failed) remove(parameters.outfile);
 	}
 	destroy_parameters(&parameters);
-	fprintf(stdout, "decode time: %d ms \n", (int)( (tCumulative * 1000) / numDecompressedImages));
-	scanf("%d");
+	if (numDecompressedImages)
+		fprintf(stdout, "decode time: %d ms \n", (int)( (tCumulative * 1000) / numDecompressedImages));
+	//getch();
 	return failed ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 /*end main*/

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -56,6 +56,9 @@
 #define strncasecmp _strnicmp
 #else
 #include <strings.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/times.h>
 #endif /* _WIN32 */
 
 #include "openjpeg.h"
@@ -840,6 +843,30 @@ int parse_DA_values( char* inArg, unsigned int *DA_x0, unsigned int *DA_y0, unsi
 	}
 }
 
+OPJ_FLOAT64 opj_clock(void) {
+#ifdef _WIN32
+	/* _WIN32: use QueryPerformance (very accurate) */
+    LARGE_INTEGER freq , t ;
+    /* freq is the clock speed of the CPU */
+    QueryPerformanceFrequency(&freq) ;
+	/* cout << "freq = " << ((double) freq.QuadPart) << endl; */
+    /* t is the high resolution performance counter (see MSDN) */
+    QueryPerformanceCounter ( & t ) ;
+    return ( t.QuadPart /(OPJ_FLOAT64) freq.QuadPart ) ;
+#else
+	/* Unix or Linux: use resource usage */
+    struct rusage t;
+    OPJ_FLOAT64 procTime;
+    /* (1) Get the rusage data structure at this moment (man getrusage) */
+    getrusage(0,&t);
+    /* (2) What is the elapsed time ? - CPU time = User time + System time */
+	/* (2a) Get the seconds */
+    procTime = (OPJ_FLOAT64)(t.ru_utime.tv_sec + t.ru_stime.tv_sec);
+    /* (2b) More precisely! Get the microseconds part ! */
+    return ( procTime + (OPJ_FLOAT64)(t.ru_utime.tv_usec + t.ru_stime.tv_usec) * 1e-6 ) ;
+#endif
+}
+
 /* -------------------------------------------------------------------------- */
 
 /**
@@ -1135,6 +1162,8 @@ int main(int argc, char **argv)
 	img_fol_t img_fol;
 	dircnt_t *dirptr = NULL;
   int failed = 0;
+  OPJ_FLOAT64 t, tCumulative = 0;
+  OPJ_UINT32 numDecompressedImages = 0;
 
 	/* set decoding parameters to default values */
 	set_default_parameters(&parameters);
@@ -1239,6 +1268,8 @@ int main(int argc, char **argv)
 		opj_set_warning_handler(l_codec, warning_callback,00);
 		opj_set_error_handler(l_codec, error_callback,00);
 
+		t = opj_clock();
+
 		/* Setup the decoder decoding parameters using user parameters */
 		if ( !opj_setup_decoder(l_codec, &(parameters.core)) ){
 			fprintf(stderr, "ERROR -> opj_decompress: failed to setup the decoder\n");
@@ -1302,6 +1333,9 @@ int main(int argc, char **argv)
 			}
 			fprintf(stdout, "tile %d is decoded!\n\n", parameters.tile_index);
 		}
+
+		tCumulative += opj_clock() - t;
+		numDecompressedImages++;
 
 		/* Close the byte stream */
 		opj_stream_destroy(l_stream);
@@ -1501,6 +1535,8 @@ int main(int argc, char **argv)
 		if(failed) remove(parameters.outfile);
 	}
 	destroy_parameters(&parameters);
+	fprintf(stdout, "decode time: %d ms \n", (int)( (tCumulative * 1000) / numDecompressedImages));
+	scanf("%d");
 	return failed ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 /*end main*/

--- a/src/lib/openjp2/opj_includes.h
+++ b/src/lib/openjp2/opj_includes.h
@@ -119,7 +119,7 @@
 #endif
 
 /* MSVC before 2013 and Borland C do not have lrintf */
-#if defined(_MSC_VER) && (_MSC_VER < 1800) || defined(__BORLANDC__)
+#if defined(_MSC_VER)  || defined(__BORLANDC__)
 static INLINE long lrintf(float f){
 #ifdef _M_X64
     return (long)((f>0.0f) ? (f + 0.5f):(f -0.5f));

--- a/src/lib/openjp2/opj_includes.h
+++ b/src/lib/openjp2/opj_includes.h
@@ -118,15 +118,20 @@
 	#endif
 #endif
 
+
+
 /* MSVC before 2013 and Borland C do not have lrintf */
-#if defined(_MSC_VER)  || defined(__BORLANDC__)
+#if defined(_MSC_VER)
+#include <intrin.h>
 static INLINE long lrintf(float f){
 #ifdef _M_X64
-    return (long)((f>0.0f) ? (f + 0.5f):(f -0.5f));
+	return _mm_cvt_ss2si(_mm_load_ss(&f));
+
+	// commented out line breaks many tests
+    ///return (long)((f>0.0f) ? (f + 0.5f):(f -0.5f));
 #else
     int i;
- 
-    _asm{
+     _asm{
         fld f
         fistp i
     };
@@ -135,6 +140,25 @@ static INLINE long lrintf(float f){
 #endif
 }
 #endif
+
+#if  defined(__BORLANDC__)
+static INLINE long lrintf(float f) {
+#ifdef _M_X64
+     return (long)((f>0.0f) ? (f + 0.5f):(f -0.5f));
+#else
+	int i;
+
+	_asm {
+		fld f
+			fistp i
+	};
+
+	return i;
+#endif
+}
+#endif
+
+
 
 #if defined(_MSC_VER) && (_MSC_VER < 1400)
 	#define vsnprintf _vsnprintf


### PR DESCRIPTION
Here are a few small T1 optimizations: removing some unnecessary calculations.
Also, there is a patch for lrintf on windows - the visual studio version has problems 
and doubles the decode time. I have also added some timing code to compress and decompress.