### PR TITLE
Fix opj_write_bytes_BE (#518)

### DIFF
--- a/src/lib/openjp2/cio.c
+++ b/src/lib/openjp2/cio.c
@@ -46,7 +46,7 @@
 
 void opj_write_bytes_BE (OPJ_BYTE * p_buffer, OPJ_UINT32 p_value, OPJ_UINT32 p_nb_bytes)
 {
-	const OPJ_BYTE * l_data_ptr = ((const OPJ_BYTE *) &p_value) + p_nb_bytes;
+	const OPJ_BYTE * l_data_ptr = ((const OPJ_BYTE *) &p_value)+sizeof(OPJ_UINT32)-p_nb_bytes;
 
 	assert(p_nb_bytes > 0 && p_nb_bytes <=  sizeof(OPJ_UINT32));
 
@@ -72,7 +72,7 @@ void opj_read_bytes_BE(const OPJ_BYTE * p_buffer, OPJ_UINT32 * p_value, OPJ_UINT
 	assert(p_nb_bytes > 0 && p_nb_bytes <= sizeof(OPJ_UINT32));
 
 	*p_value = 0;
-	memcpy(l_data_ptr+4-p_nb_bytes,p_buffer,p_nb_bytes);
+	memcpy(l_data_ptr+sizeof(OPJ_UINT32)-p_nb_bytes,p_buffer,p_nb_bytes);
 }
 
 void opj_read_bytes_LE(const OPJ_BYTE * p_buffer, OPJ_UINT32 * p_value, OPJ_UINT32 p_nb_bytes)


### PR DESCRIPTION
This patch, originally by @szukw000, fixes the issue where opj_compress + opj_decompress fails on bigendian systems.