### PR TITLE
fix Suspicious code in j2k.c #517

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -10021,7 +10021,6 @@ OPJ_BOOL opj_j2k_encode(opj_j2k_t * p_j2k,
 												                }
 												                return OPJ_FALSE;
 												        }
-												        opj_alloc_tile_component_data(l_tilec);
                         }
                 }
                 l_current_tile_size = opj_tcd_get_encoded_tile_size(p_j2k->m_tcd);


### PR DESCRIPTION
Okay, so this is my very first pull request, removing the apparently superfluous call in line 10024 opj_alloc_tile_component_data(l_tilec);

I tested this manually and reran the regression tests encountering no apparent differences. Please be gentle on feedback as I'm quite new to collaborating on github.