### PR TITLE
Add jpylyzer tests for JP2 compression

### DIFF
--- a/cmake/FindJPYLYZER.cmake
+++ b/cmake/FindJPYLYZER.cmake
@@ -1,0 +1,12 @@
+#
+# this module looks for JPYLYZER
+# http://jpylyzer.openpreservation.org
+#
+
+find_program(JPYLYZER_EXECUTABLE
+  jpylyzer
+  )
+
+mark_as_advanced(
+  JPYLYZER_EXECUTABLE
+  )

--- a/tests/nonregression/CMakeLists.txt
+++ b/tests/nonregression/CMakeLists.txt
@@ -340,17 +340,16 @@ foreach(OPJ_TEST_CMD_LINE ${OPJ_TEST_CMD_LINE_LIST})
           
           # Test the encoded file is a valid JP2 file
           if (JPYLYZER_EXECUTABLE)
-          	if (${OUTPUT_FILENAME} MATCHES "\\.jp2$")
-          		add_test(NAME NR-ENC-${INPUT_FILENAME_NAME}-${IT_TEST_ENC}-jpylyser
-              	COMMAND ${JPYLYZER_EXECUTABLE}
-              	${OUTPUT_FILENAME}
-              	)
+            if (${OUTPUT_FILENAME} MATCHES "\\.jp2$")
+              add_test(NAME NR-ENC-${INPUT_FILENAME_NAME}-${IT_TEST_ENC}-jpylyser
+                COMMAND ${JPYLYZER_EXECUTABLE}
+                ${OUTPUT_FILENAME}
+                )
               set_tests_properties(NR-ENC-${INPUT_FILENAME_NAME}-${IT_TEST_ENC}-jpylyser PROPERTIES 
-              	DEPENDS NR-ENC-${INPUT_FILENAME_NAME}-${IT_TEST_ENC}-encode
-  							PASS_REGULAR_EXPRESSION "<isValidJP2>True</isValidJP2>"
-								)
-								
-          	endif()
+                DEPENDS NR-ENC-${INPUT_FILENAME_NAME}-${IT_TEST_ENC}-encode
+                PASS_REGULAR_EXPRESSION "<isValidJP2>True</isValidJP2>"
+                )		
+            endif()
           endif(JPYLYZER_EXECUTABLE)
       endif()
 

--- a/tests/nonregression/CMakeLists.txt
+++ b/tests/nonregression/CMakeLists.txt
@@ -13,6 +13,8 @@ set(INPUT_CONF_PATH ${OPJ_DATA_ROOT}/input/conformance)
 
 # need kdu_expand if possible
 find_package(KAKADU)
+# need jpylyzer if possible
+find_package(JPYLYZER)
 
 #########################################################################
 # GENERATION OF THE TEST SUITE (DUMP)
@@ -335,6 +337,21 @@ foreach(OPJ_TEST_CMD_LINE ${OPJ_TEST_CMD_LINE_LIST})
                                  NR-ENC-${INPUT_FILENAME_NAME}-${IT_TEST_ENC}-decode-ref)
 
           endif()
+          
+          # Test the encoded file is a valid JP2 file
+          if (JPYLYZER_EXECUTABLE)
+          	if (${OUTPUT_FILENAME} MATCHES "\\.jp2$")
+          		add_test(NAME NR-ENC-${INPUT_FILENAME_NAME}-${IT_TEST_ENC}-jpylyser
+              	COMMAND ${JPYLYZER_EXECUTABLE}
+              	${OUTPUT_FILENAME}
+              	)
+              set_tests_properties(NR-ENC-${INPUT_FILENAME_NAME}-${IT_TEST_ENC}-jpylyser PROPERTIES 
+              	DEPENDS NR-ENC-${INPUT_FILENAME_NAME}-${IT_TEST_ENC}-encode
+  							PASS_REGULAR_EXPRESSION "<isValidJP2>True</isValidJP2>"
+								)
+								
+          	endif()
+          endif(JPYLYZER_EXECUTABLE)
       endif()
 
     # DECODER TEST SUITE


### PR DESCRIPTION
This will help to guarantee that OpenJpeg generates valid JP2 files.