### PR TITLE
Added missing casts for return values of opj_malloc()/opj_calloc().

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -3562,7 +3562,7 @@ static OPJ_BOOL opj_j2k_read_ppm (
 		return OPJ_FALSE;
 	}
 	
-	l_cp->ppm_markers[l_Z_ppm].m_data = opj_malloc(p_header_size);
+	l_cp->ppm_markers[l_Z_ppm].m_data = (OPJ_BYTE *) opj_malloc(p_header_size);
 	if (l_cp->ppm_markers[l_Z_ppm].m_data == NULL) {
 		/* clean up to be done on l_cp destruction */
 		opj_event_msg(p_manager, EVT_ERROR, "Not enough memory to read PPM marker\n");
@@ -3784,7 +3784,7 @@ static OPJ_BOOL opj_j2k_read_ppt (  opj_j2k_t *p_j2k,
 		return OPJ_FALSE;
 	}
 	
-	l_tcp->ppt_markers[l_Z_ppt].m_data = opj_malloc(p_header_size);
+	l_tcp->ppt_markers[l_Z_ppt].m_data = (OPJ_BYTE *) opj_malloc(p_header_size);
 	if (l_tcp->ppt_markers[l_Z_ppt].m_data == NULL) {
 		/* clean up to be done on l_tcp destruction */
 		opj_event_msg(p_manager, EVT_ERROR, "Not enough memory to read PPT marker\n");

--- a/src/lib/openjp2/jp2.c
+++ b/src/lib/openjp2/jp2.c
@@ -889,7 +889,7 @@ static OPJ_BOOL opj_jp2_check_color(opj_image_t *image, opj_jp2_color_t *color, 
 			}
 		}
 
-		pcol_usage = opj_calloc(nr_channels, sizeof(OPJ_BOOL));
+		pcol_usage = (OPJ_BOOL *) opj_calloc(nr_channels, sizeof(OPJ_BOOL));
 		if (!pcol_usage) {
 			opj_event_msg(p_manager, EVT_ERROR, "Unexpected OOM.\n");
 			return OPJ_FALSE;


### PR DESCRIPTION
I'm compiling the OpenJPEG source also with the .NET C++ compiler. In a few places the casts for the return values of opj_malloc()/opj_calloc() are missing, which prevents successful compilation in C++ mode. As the casts for the return values of opj_malloc()/opj_calloc() are present otherwise in the rest of the OpenJPEG source code, I guess the missing casts were left out by accident.