### PR TITLE
Fix warnings for C++

### DIFF
--- a/src/bin/common/opj_getopt.c
+++ b/src/bin/common/opj_getopt.c
@@ -66,7 +66,7 @@ void opj_reset_options_reading(void) {
 int opj_getopt(int nargc, char *const *nargv, const char *ostr) {
 #  define __progname nargv[0]
   static char *place = EMSG;	/* option letter processing */
-  char *oli = NULL;			/* option letter list index */
+  const char *oli = NULL;	/* option letter list index */
 
   if (opj_optreset || !*place) {	/* update scanning pointer */
     opj_optreset = 0;
@@ -125,7 +125,7 @@ int opj_getopt(int nargc, char *const *nargv, const char *ostr) {
 int opj_getopt_long(int argc, char * const argv[], const char *optstring,
 const opj_option_t *longopts, int totlen) {
 	static int lastidx,lastofs;
-	char *tmp;
+	const char *tmp;
 	int i,len;
 	char param = 1;
 

--- a/src/bin/jp2/convertpng.c
+++ b/src/bin/jp2/convertpng.c
@@ -211,7 +211,7 @@ opj_image_t *pngtoimage(const char *read_idf, opj_cparameters_t * params)
 	image->x1 = (OPJ_UINT32)(image->x0 + (width  - 1) * (OPJ_UINT32)params->subsampling_dx + 1 + image->x0);
 	image->y1 = (OPJ_UINT32)(image->y0 + (height - 1) * (OPJ_UINT32)params->subsampling_dy + 1 + image->y0);
 	
-	row32s = malloc((size_t)width * nr_comp * sizeof(OPJ_INT32));
+	row32s = (OPJ_INT32 *)malloc((size_t)width * nr_comp * sizeof(OPJ_INT32));
 	if(row32s == NULL) goto fin;
 	
 	/* Set alpha channel */

--- a/src/bin/jp2/converttif.c
+++ b/src/bin/jp2/converttif.c
@@ -290,7 +290,7 @@ int imagetotif(opj_image_t * image, const char *outfile)
 		TIFFClose(tif);
 		return 1;
 	}
-	buffer32s = malloc((OPJ_SIZE_T)width * numcomps * sizeof(OPJ_INT32));
+	buffer32s = (OPJ_INT32 *)malloc((OPJ_SIZE_T)width * numcomps * sizeof(OPJ_INT32));
 	if (buffer32s == NULL) {
 		_TIFFfree(buf);
 		TIFFClose(tif);
@@ -299,7 +299,7 @@ int imagetotif(opj_image_t * image, const char *outfile)
 	
 	for (i = 0; i < image->comps[0].h; ++i) {
 		cvtPxToCx(planes, buffer32s, (OPJ_SIZE_T)width, adjust);
-		cvt32sToTif(buffer32s, buf, (OPJ_SIZE_T)width * numcomps);
+		cvt32sToTif(buffer32s, (OPJ_BYTE *)buf, (OPJ_SIZE_T)width * numcomps);
 		(void)TIFFWriteEncodedStrip(tif, i, (void*)buf, strip_size);
 		planes[0] += width;
 		planes[1] += width;
@@ -590,7 +590,7 @@ opj_image_t* tiftoimage(const char *filename, opj_cparameters_t *parameters)
 		return NULL;
 	}
 	rowStride = ((OPJ_SIZE_T)w * tiSpp * tiBps + 7U) / 8U;
-	buffer32s = malloc((OPJ_SIZE_T)w * tiSpp * sizeof(OPJ_INT32));
+	buffer32s = (OPJ_INT32 *)malloc((OPJ_SIZE_T)w * tiSpp * sizeof(OPJ_INT32));
 	if (buffer32s == NULL) {
 		_TIFFfree(buf);
 		TIFFClose(tif);

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -291,7 +291,7 @@ static OPJ_BOOL parse_precision(const char* option, opj_decompress_parameters* p
 			
 			if (parameters->precision == NULL) {
 				/* first one */
-				parameters->precision = malloc(sizeof(opj_precision));
+				parameters->precision = (opj_precision *)malloc(sizeof(opj_precision));
 				if (parameters->precision == NULL) {
 					fprintf(stderr,"Could not allocate memory for precision option\n");
 					l_result = OPJ_FALSE;
@@ -307,7 +307,7 @@ static OPJ_BOOL parse_precision(const char* option, opj_decompress_parameters* p
 					break;
 				}
 				
-				l_new = realloc(parameters->precision, l_new_size * sizeof(opj_precision));
+				l_new = (opj_precision *)realloc(parameters->precision, l_new_size * sizeof(opj_precision));
 				if (l_new == NULL) {
 					fprintf(stderr,"Could not allocate memory for precision option\n");
 					l_result = OPJ_FALSE;
@@ -400,7 +400,7 @@ int get_file_format(const char *filename) {
 	unsigned int i;
 	static const char *extension[] = {"pgx", "pnm", "pgm", "ppm", "bmp","tif", "raw", "rawl", "tga", "png", "j2k", "jp2", "jpt", "j2c", "jpc" };
 	static const int format[] = { PGX_DFMT, PXM_DFMT, PXM_DFMT, PXM_DFMT, BMP_DFMT, TIF_DFMT, RAW_DFMT, RAWL_DFMT, TGA_DFMT, PNG_DFMT, J2K_CFMT, JP2_CFMT, JPT_CFMT, J2K_CFMT, J2K_CFMT };
-	char * ext = strrchr(filename, '.');
+	const char * ext = strrchr(filename, '.');
 	if (ext == NULL)
 		return -1;
 	ext++;

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -171,7 +171,7 @@ static int get_file_format(const char *filename) {
 	unsigned int i;
 	static const char *extension[] = {"pgx", "pnm", "pgm", "ppm", "bmp","tif", "raw", "tga", "png", "j2k", "jp2", "jpt", "j2c", "jpc"  };
 	static const int format[] = { PGX_DFMT, PXM_DFMT, PXM_DFMT, PXM_DFMT, BMP_DFMT, TIF_DFMT, RAW_DFMT, TGA_DFMT, PNG_DFMT, J2K_CFMT, JP2_CFMT, JPT_CFMT, J2K_CFMT, J2K_CFMT };
-	char * ext = strrchr(filename, '.');
+	const char *ext = strrchr(filename, '.');
 	if (ext == NULL)
 		return -1;
 	ext++;


### PR DESCRIPTION
g++ complains about invalid conversions like these ones:

error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
error: invalid conversion from ‘void*’ to ‘opj_precision* {aka opj_prec*}’ [-fpermissive]

Signed-off-by: Stefan Weil <sw@weilnetz.de>