### PR TITLE
Fix OpenJPEG GitHub issue #633.

### DIFF
--- a/src/lib/openjp2/opj_clock.c
+++ b/src/lib/openjp2/opj_clock.c
@@ -29,6 +29,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "opj_includes.h"
+
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -36,7 +38,6 @@
 #include <sys/resource.h>
 #include <sys/times.h>
 #endif /* _WIN32 */
-#include "opj_includes.h"
 
 OPJ_FLOAT64 opj_clock(void) {
 #ifdef _WIN32


### PR DESCRIPTION
"opj_includes.h" must be included before system headers, otherwise
inconsistent definitions of configuration macros lead to build
failures on AIX.