### PR TITLE
Fix repository for JPEG2000 test data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,8 +291,8 @@ if(BUILD_TESTING)
     include(CTest)
 
     # Search openjpeg data needed for the tests
-    # They could be found via svn on the OpenJPEG google code project
-    # svn checkout http://openjpeg.googlecode.com/svn/data (about 70 Mo)
+    # They could be found via git on the OpenJPEG GitHub code project
+    # git clone https://github.com/uclouvain/openjpeg-data.git
     find_path(OPJ_DATA_ROOT README-OPJ-Data
       PATHS $ENV{OPJ_DATA_ROOT} ${CMAKE_SOURCE_DIR}/../data
       NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH

--- a/INSTALL
+++ b/INSTALL
@@ -44,7 +44,7 @@ Main available cmake flags:
     cmake . -DBUILD_TESTING:BOOL=ON -DOPJ_DATA_ROOT:PATH='path/to/the/data/directory'
     make
     make Experimental
-  Note : JPEG2000 test files are available with 'svn checkout http://openjpeg.googlecode.com/svn/data' (about 70 Mo).
+  Note : JPEG2000 test files are available with 'git clone https://github.com/uclouvain/openjpeg-data.git'.
   If '-DOPJ_DATA_ROOT:PATH' option is omitted, test files will be automatically searched in '${CMAKE_SOURCE_DIR}/../data',
   corresponding to the location of the data directory when compiling from the trunk (and assuming the data directory has
   been checked out of course).


### PR DESCRIPTION
The data is now maintained in a git repository on Github.

Signed-off-by: Stefan Weil <sw@weilnetz.de>