### PR TITLE
Fix HP compiler warning about redeclaration of function (#640)

### DIFF
--- a/src/lib/openjp2/dwt.c
+++ b/src/lib/openjp2/dwt.c
@@ -795,7 +795,7 @@ static void opj_v4dwt_decode_step2(opj_v4_t* l, opj_v4_t* w, OPJ_INT32 k, OPJ_IN
 /* <summary>                             */
 /* Inverse 9-7 wavelet transform in 1-D. */
 /* </summary>                            */
-void opj_v4dwt_decode(opj_v4dwt_t* restrict dwt)
+static void opj_v4dwt_decode(opj_v4dwt_t* restrict dwt)
 {
 	OPJ_INT32 a, b;
 	if(dwt->cas == 0) {

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1338,7 +1338,7 @@ static OPJ_BOOL opj_t2_skip_packet_data(   opj_t2_t* p_t2,
 }
 
 
-OPJ_BOOL opj_t2_init_seg(   opj_tcd_cblk_dec_t* cblk,
+static OPJ_BOOL opj_t2_init_seg(   opj_tcd_cblk_dec_t* cblk,
                             OPJ_UINT32 index, 
                             OPJ_UINT32 cblksty, 
                             OPJ_UINT32 first)


### PR DESCRIPTION
HP compiler warns:
cc: "dwt.c", line 798: warning 562: Redeclaration of "opj_v4dwt_decode"
with a different storage class specifier: "opj_v4dwt_decode" will have
internal linkage.
cc: "t2.c", line 1341: warning 562: Redeclaration of "opj_t2_init_seg"
with a different storage class specifier: "opj_t2_init_seg" will have
internal linkage.

Fix for issue #640.