### PR TITLE
Avoid pointer arithmetic with (void *) pointers

### DIFF
--- a/src/lib/openjp2/opj_malloc.c
+++ b/src/lib/openjp2/opj_malloc.c
@@ -166,7 +166,7 @@ static INLINE void *opj_aligned_realloc_n(void *ptr, size_t alignment, size_t ne
       size_t new_offset;
 
       /* realloc created a new copy, realign the copied memory block */
-      old_offset = (size_t)(ptr - oldmem);
+      old_offset = (size_t)((OPJ_UINT8*)ptr - (OPJ_UINT8*)oldmem);
 
       /* offset = ((alignment + 1U) - ((size_t)(mem + sizeof(void*)) & alignment)) & alignment; */
       /* Use the fact that alignment + 1U is a power of 2 */


### PR DESCRIPTION
Taking the difference of two void * pointers is not defined according to the C specification, and for example the z/OS compiler warns:

./opj_malloc.c:169   Operation between types `void*` and `void*` is not allowed.