### PR TITLE
Fix support of posix_memalloc for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,8 +231,10 @@ check_include_files(malloc.h OPJ_HAVE_MALLOC_H)
 include(CheckSymbolExists)
 # _aligned_alloc https://msdn.microsoft.com/en-us/library/8z34s9c6.aspx
 check_symbol_exists(_aligned_malloc malloc.h OPJ_HAVE__ALIGNED_MALLOC)
-# posix_memalign
+# posix_memalign (needs _POSIX_C_SOURCE >= 200112L on Linux)
+set(CMAKE_REQUIRED_DEFINITIONS -D_POSIX_C_SOURCE=200112L)
 check_symbol_exists(posix_memalign stdlib.h OPJ_HAVE_POSIX_MEMALIGN)
+unset(CMAKE_REQUIRED_DEFINITIONS)
 # memalign (obsolete)
 check_symbol_exists(memalign malloc.h OPJ_HAVE_MEMALIGN)
 #-----------------------------------------------------------------------------

--- a/src/lib/openjp2/opj_config_private.h.cmake.in
+++ b/src/lib/openjp2/opj_config_private.h.cmake.in
@@ -28,6 +28,13 @@
 /* check if function `posix_memalign` exists */
 #cmakedefine OPJ_HAVE_POSIX_MEMALIGN
 
+#if !defined(_POSIX_C_SOURCE)
+#if defined(OPJ_HAVE_FSEEKO) || defined(OPJ_HAVE_POSIX_MEMALIGN)
+/* Get declarations of fseeko, ftello, posix_memalign. */
+#define _POSIX_C_SOURCE 200112L
+#endif
+#endif
+
 /* Byte order.  */
 /* All compilers that support Mac OS X define either __BIG_ENDIAN__ or
 __LITTLE_ENDIAN__ to match the endianness of the architecture being


### PR DESCRIPTION
posix_memalloc is only declared conditionally in stdlib.h,
so add one of the possible definitions to get the declaration.

Signed-off-by: Stefan Weil <sw@weilnetz.de>