### PR TITLE
Add missing source for the JPIP library and executables (issue #658)

### DIFF
--- a/src/lib/openjpip/CMakeLists.txt
+++ b/src/lib/openjpip/CMakeLists.txt
@@ -36,6 +36,7 @@ set(OPENJPIP_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/session_manager.c
   ${CMAKE_CURRENT_SOURCE_DIR}/jpip_parser.c
   ${CMAKE_CURRENT_SOURCE_DIR}/sock_manager.c
+  ${OPENJPEG_SOURCE_DIR}/src/lib/openjp2/opj_malloc.c
   )
 
 set(SERVER_SRCS


### PR DESCRIPTION
They all need opj_malloc and other functions from opc_malloc.c.

Signed-off-by: Stefan Weil <sw@weilnetz.de>