### PR TITLE
Changed 'restrict' define to 'OPJ_RESTRICT'

### DIFF
--- a/src/lib/openjp2/dwt.c
+++ b/src/lib/openjp2/dwt.c
@@ -129,16 +129,16 @@ static OPJ_BOOL opj_dwt_decode_tile(opj_tcd_tilecomp_t* tilec, OPJ_UINT32 i, DWT
 static OPJ_BOOL opj_dwt_encode_procedure(	opj_tcd_tilecomp_t * tilec,
 										    void (*p_function)(OPJ_INT32 *, OPJ_INT32,OPJ_INT32,OPJ_INT32) );
 
-static OPJ_UINT32 opj_dwt_max_resolution(opj_tcd_resolution_t* restrict r, OPJ_UINT32 i);
+static OPJ_UINT32 opj_dwt_max_resolution(opj_tcd_resolution_t* OPJ_RESTRICT r, OPJ_UINT32 i);
 
 /* <summary>                             */
 /* Inverse 9-7 wavelet transform in 1-D. */
 /* </summary>                            */
-static void opj_v4dwt_decode(opj_v4dwt_t* restrict dwt);
+static void opj_v4dwt_decode(opj_v4dwt_t* OPJ_RESTRICT dwt);
 
-static void opj_v4dwt_interleave_h(opj_v4dwt_t* restrict w, OPJ_FLOAT32* restrict a, OPJ_INT32 x, OPJ_INT32 size);
+static void opj_v4dwt_interleave_h(opj_v4dwt_t* OPJ_RESTRICT w, OPJ_FLOAT32* OPJ_RESTRICT a, OPJ_INT32 x, OPJ_INT32 size);
 
-static void opj_v4dwt_interleave_v(opj_v4dwt_t* restrict v , OPJ_FLOAT32* restrict a , OPJ_INT32 x, OPJ_INT32 nb_elts_read);
+static void opj_v4dwt_interleave_v(opj_v4dwt_t* OPJ_RESTRICT v , OPJ_FLOAT32* OPJ_RESTRICT a , OPJ_INT32 x, OPJ_INT32 nb_elts_read);
 
 #ifdef __SSE__
 static void opj_v4dwt_decode_step1_sse(opj_v4_t* w, OPJ_INT32 count, const __m128 c);
@@ -541,7 +541,7 @@ void opj_dwt_calc_explicit_stepsizes(opj_tccp_t * tccp, OPJ_UINT32 prec) {
 /* <summary>                             */
 /* Determine maximum computed resolution level for inverse wavelet transform */
 /* </summary>                            */
-static OPJ_UINT32 opj_dwt_max_resolution(opj_tcd_resolution_t* restrict r, OPJ_UINT32 i) {
+static OPJ_UINT32 opj_dwt_max_resolution(opj_tcd_resolution_t* OPJ_RESTRICT r, OPJ_UINT32 i) {
 	OPJ_UINT32 mr	= 0;
 	OPJ_UINT32 w;
 	while( --i ) {
@@ -580,7 +580,7 @@ static OPJ_BOOL opj_dwt_decode_tile(opj_tcd_tilecomp_t* tilec, OPJ_UINT32 numres
 	v.mem = h.mem;
 
 	while( --numres) {
-		OPJ_INT32 * restrict tiledp = tilec->data;
+		OPJ_INT32 * OPJ_RESTRICT tiledp = tilec->data;
 		OPJ_UINT32 j;
 
 		++tr;
@@ -615,8 +615,8 @@ static OPJ_BOOL opj_dwt_decode_tile(opj_tcd_tilecomp_t* tilec, OPJ_UINT32 numres
 	return OPJ_TRUE;
 }
 
-static void opj_v4dwt_interleave_h(opj_v4dwt_t* restrict w, OPJ_FLOAT32* restrict a, OPJ_INT32 x, OPJ_INT32 size){
-	OPJ_FLOAT32* restrict bi = (OPJ_FLOAT32*) (w->wavelet + w->cas);
+static void opj_v4dwt_interleave_h(opj_v4dwt_t* OPJ_RESTRICT w, OPJ_FLOAT32* OPJ_RESTRICT a, OPJ_INT32 x, OPJ_INT32 size){
+	OPJ_FLOAT32* OPJ_RESTRICT bi = (OPJ_FLOAT32*) (w->wavelet + w->cas);
 	OPJ_INT32 count = w->sn;
 	OPJ_INT32 i, k;
 
@@ -658,8 +658,8 @@ static void opj_v4dwt_interleave_h(opj_v4dwt_t* restrict w, OPJ_FLOAT32* restric
 	}
 }
 
-static void opj_v4dwt_interleave_v(opj_v4dwt_t* restrict v , OPJ_FLOAT32* restrict a , OPJ_INT32 x, OPJ_INT32 nb_elts_read){
-	opj_v4_t* restrict bi = v->wavelet + v->cas;
+static void opj_v4dwt_interleave_v(opj_v4dwt_t* OPJ_RESTRICT v , OPJ_FLOAT32* OPJ_RESTRICT a , OPJ_INT32 x, OPJ_INT32 nb_elts_read){
+	opj_v4_t* OPJ_RESTRICT bi = v->wavelet + v->cas;
 	OPJ_INT32 i;
 
 	for(i = 0; i < v->sn; ++i){
@@ -677,7 +677,7 @@ static void opj_v4dwt_interleave_v(opj_v4dwt_t* restrict v , OPJ_FLOAT32* restri
 #ifdef __SSE__
 
 static void opj_v4dwt_decode_step1_sse(opj_v4_t* w, OPJ_INT32 count, const __m128 c){
-	__m128* restrict vw = (__m128*) w;
+	__m128* OPJ_RESTRICT vw = (__m128*) w;
 	OPJ_INT32 i;
 	/* 4x unrolled loop */
 	for(i = 0; i < count >> 2; ++i){
@@ -698,8 +698,8 @@ static void opj_v4dwt_decode_step1_sse(opj_v4_t* w, OPJ_INT32 count, const __m12
 }
 
 void opj_v4dwt_decode_step2_sse(opj_v4_t* l, opj_v4_t* w, OPJ_INT32 k, OPJ_INT32 m, __m128 c){
-	__m128* restrict vl = (__m128*) l;
-	__m128* restrict vw = (__m128*) w;
+	__m128* OPJ_RESTRICT vl = (__m128*) l;
+	__m128* OPJ_RESTRICT vw = (__m128*) w;
 	OPJ_INT32 i;
 	__m128 tmp1, tmp2, tmp3;
 	tmp1 = vl[0];
@@ -727,7 +727,7 @@ void opj_v4dwt_decode_step2_sse(opj_v4_t* l, opj_v4_t* w, OPJ_INT32 k, OPJ_INT32
 
 static void opj_v4dwt_decode_step1(opj_v4_t* w, OPJ_INT32 count, const OPJ_FLOAT32 c)
 {
-	OPJ_FLOAT32* restrict fw = (OPJ_FLOAT32*) w;
+	OPJ_FLOAT32* OPJ_RESTRICT fw = (OPJ_FLOAT32*) w;
 	OPJ_INT32 i;
 	for(i = 0; i < count; ++i){
 		OPJ_FLOAT32 tmp1 = fw[i*8    ];
@@ -795,7 +795,7 @@ static void opj_v4dwt_decode_step2(opj_v4_t* l, opj_v4_t* w, OPJ_INT32 k, OPJ_IN
 /* <summary>                             */
 /* Inverse 9-7 wavelet transform in 1-D. */
 /* </summary>                            */
-static void opj_v4dwt_decode(opj_v4dwt_t* restrict dwt)
+static void opj_v4dwt_decode(opj_v4dwt_t* OPJ_RESTRICT dwt)
 {
 	OPJ_INT32 a, b;
 	if(dwt->cas == 0) {
@@ -832,7 +832,7 @@ static void opj_v4dwt_decode(opj_v4dwt_t* restrict dwt)
 /* <summary>                             */
 /* Inverse 9-7 wavelet transform in 2-D. */
 /* </summary>                            */
-OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* restrict tilec, OPJ_UINT32 numres)
+OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* OPJ_RESTRICT tilec, OPJ_UINT32 numres)
 {
 	opj_v4dwt_t h;
 	opj_v4dwt_t v;
@@ -852,7 +852,7 @@ OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* restrict tilec, OPJ_UINT32 numr
 	v.wavelet = h.wavelet;
 
 	while( --numres) {
-		OPJ_FLOAT32 * restrict aj = (OPJ_FLOAT32*) tilec->data;
+		OPJ_FLOAT32 * OPJ_RESTRICT aj = (OPJ_FLOAT32*) tilec->data;
 		OPJ_UINT32 bufsize = (OPJ_UINT32)((tilec->x1 - tilec->x0) * (tilec->y1 - tilec->y0));
 		OPJ_INT32 j;
 

--- a/src/lib/openjp2/dwt.h
+++ b/src/lib/openjp2/dwt.h
@@ -93,7 +93,7 @@ Apply an irreversible inverse DWT transform to a component of an image.
 @param tilec Tile component information (current tile)
 @param numres Number of resolution levels to decode
 */
-OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* restrict tilec, OPJ_UINT32 numres);
+OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* OPJ_RESTRICT tilec, OPJ_UINT32 numres);
 
 /**
 Get the gain of a subband for the irreversible 9-7 DWT.

--- a/src/lib/openjp2/mct.c
+++ b/src/lib/openjp2/mct.c
@@ -74,9 +74,9 @@ const OPJ_FLOAT64 * opj_mct_get_mct_norms_real ()
 /* </summary> */
 #ifdef __SSE2__
 void opj_mct_encode(
-		OPJ_INT32* restrict c0,
-		OPJ_INT32* restrict c1,
-		OPJ_INT32* restrict c2,
+		OPJ_INT32* OPJ_RESTRICT c0,
+		OPJ_INT32* OPJ_RESTRICT c1,
+		OPJ_INT32* OPJ_RESTRICT c2,
 		OPJ_UINT32 n)
 {
 	OPJ_SIZE_T i;
@@ -116,9 +116,9 @@ void opj_mct_encode(
 }
 #else
 void opj_mct_encode(
-		OPJ_INT32* restrict c0,
-		OPJ_INT32* restrict c1,
-		OPJ_INT32* restrict c2,
+		OPJ_INT32* OPJ_RESTRICT c0,
+		OPJ_INT32* OPJ_RESTRICT c1,
+		OPJ_INT32* OPJ_RESTRICT c2,
 		OPJ_UINT32 n)
 {
 	OPJ_SIZE_T i;
@@ -143,9 +143,9 @@ void opj_mct_encode(
 /* </summary> */
 #ifdef __SSE2__
 void opj_mct_decode(
-		OPJ_INT32* restrict c0,
-		OPJ_INT32* restrict c1,
-		OPJ_INT32* restrict c2,
+		OPJ_INT32* OPJ_RESTRICT c0,
+		OPJ_INT32* OPJ_RESTRICT c1,
+		OPJ_INT32* OPJ_RESTRICT c2,
 		OPJ_UINT32 n)
 {
 	OPJ_SIZE_T i;
@@ -178,9 +178,9 @@ void opj_mct_decode(
 }
 #else
 void opj_mct_decode(
-		OPJ_INT32* restrict c0,
-		OPJ_INT32* restrict c1, 
-		OPJ_INT32* restrict c2, 
+		OPJ_INT32* OPJ_RESTRICT c0,
+		OPJ_INT32* OPJ_RESTRICT c1, 
+		OPJ_INT32* OPJ_RESTRICT c2, 
 		OPJ_UINT32 n)
 {
 	OPJ_UINT32 i;
@@ -210,9 +210,9 @@ OPJ_FLOAT64 opj_mct_getnorm(OPJ_UINT32 compno) {
 /* </summary> */
 #ifdef __SSE4_1__
 void opj_mct_encode_real(
-												 OPJ_INT32* restrict c0,
-												 OPJ_INT32* restrict c1,
-												 OPJ_INT32* restrict c2,
+												 OPJ_INT32* OPJ_RESTRICT c0,
+												 OPJ_INT32* OPJ_RESTRICT c1,
+												 OPJ_INT32* OPJ_RESTRICT c2,
 												 OPJ_UINT32 n)
 {
 	OPJ_SIZE_T i;
@@ -351,9 +351,9 @@ void opj_mct_encode_real(
 }
 #else
 void opj_mct_encode_real(
-		OPJ_INT32* restrict c0,
-		OPJ_INT32* restrict c1,
-		OPJ_INT32* restrict c2,
+		OPJ_INT32* OPJ_RESTRICT c0,
+		OPJ_INT32* OPJ_RESTRICT c1,
+		OPJ_INT32* OPJ_RESTRICT c2,
 		OPJ_UINT32 n)
 {
 	OPJ_UINT32 i;
@@ -375,9 +375,9 @@ void opj_mct_encode_real(
 /* Inverse irreversible MCT. */
 /* </summary> */
 void opj_mct_decode_real(
-		OPJ_FLOAT32* restrict c0,
-		OPJ_FLOAT32* restrict c1,
-		OPJ_FLOAT32* restrict c2,
+		OPJ_FLOAT32* OPJ_RESTRICT c0,
+		OPJ_FLOAT32* OPJ_RESTRICT c1,
+		OPJ_FLOAT32* OPJ_RESTRICT c2,
 		OPJ_UINT32 n)
 {
 	OPJ_UINT32 i;

--- a/src/lib/openjp2/opj_includes.h
+++ b/src/lib/openjp2/opj_includes.h
@@ -112,12 +112,16 @@
 #if (__STDC_VERSION__ != 199901L)
 	/* Not a C99 compiler */
 	#ifdef __GNUC__
-		#define restrict __restrict__
+		#define OPJ_RESTRICT __restrict__
+	#elif (_MSC_VER >= 1400)
+		#define OPJ_RESTRICT __restrict
 	#else
-		#define restrict /* restrict */
+		#define OPJ_RESTRICT /* restrict */
 	#endif
 #endif
-
+#ifndef OPJ_RESTRICT
+	#define OPJ_RESTRICT restrict
+#endif
 
 
 /* MSVC before 2013 and Borland C do not have lrintf */

--- a/src/lib/openjp2/t1.c
+++ b/src/lib/openjp2/t1.c
@@ -1280,14 +1280,14 @@ OPJ_BOOL opj_t1_decode_cblks(   opj_t1_t* t1,
 		opj_tcd_resolution_t* res = &tilec->resolutions[resno];
 
 		for (bandno = 0; bandno < res->numbands; ++bandno) {
-			opj_tcd_band_t* restrict band = &res->bands[bandno];
+			opj_tcd_band_t* OPJ_RESTRICT band = &res->bands[bandno];
 
 			for (precno = 0; precno < res->pw * res->ph; ++precno) {
 				opj_tcd_precinct_t* precinct = &band->precincts[precno];
 
 				for (cblkno = 0; cblkno < precinct->cw * precinct->ch; ++cblkno) {
 					opj_tcd_cblk_dec_t* cblk = &precinct->cblks.dec[cblkno];
-					OPJ_INT32* restrict datap;
+					OPJ_INT32* OPJ_RESTRICT datap;
 					OPJ_UINT32 cblk_w, cblk_h;
 					OPJ_INT32 x, y;
 					OPJ_UINT32 i, j;
@@ -1330,7 +1330,7 @@ OPJ_BOOL opj_t1_decode_cblks(   opj_t1_t* t1,
 						}
 					}
 					if (tccp->qmfbid == 1) {
-                        OPJ_INT32* restrict tiledp = &tilec->data[(OPJ_UINT32)y * tile_w + (OPJ_UINT32)x];
+                        OPJ_INT32* OPJ_RESTRICT tiledp = &tilec->data[(OPJ_UINT32)y * tile_w + (OPJ_UINT32)x];
 						for (j = 0; j < cblk_h; ++j) {
 							for (i = 0; i < cblk_w; ++i) {
 								OPJ_INT32 tmp = datap[(j * cblk_w) + i];
@@ -1338,9 +1338,9 @@ OPJ_BOOL opj_t1_decode_cblks(   opj_t1_t* t1,
 							}
 						}
 					} else {		/* if (tccp->qmfbid == 0) */
-                        OPJ_FLOAT32* restrict tiledp = (OPJ_FLOAT32*) &tilec->data[(OPJ_UINT32)y * tile_w + (OPJ_UINT32)x];
+                        OPJ_FLOAT32* OPJ_RESTRICT tiledp = (OPJ_FLOAT32*) &tilec->data[(OPJ_UINT32)y * tile_w + (OPJ_UINT32)x];
 						for (j = 0; j < cblk_h; ++j) {
-                            OPJ_FLOAT32* restrict tiledp2 = tiledp;
+                            OPJ_FLOAT32* OPJ_RESTRICT tiledp2 = tiledp;
 							for (i = 0; i < cblk_w; ++i) {
                                 OPJ_FLOAT32 tmp = (OPJ_FLOAT32)*datap * band->stepsize;
                                 *tiledp2 = tmp;
@@ -1472,7 +1472,7 @@ OPJ_BOOL opj_t1_encode_cblks(   opj_t1_t *t1,
 			opj_tcd_resolution_t *res = &tilec->resolutions[resno];
 
 			for (bandno = 0; bandno < res->numbands; ++bandno) {
-				opj_tcd_band_t* restrict band = &res->bands[bandno];
+				opj_tcd_band_t* OPJ_RESTRICT band = &res->bands[bandno];
                 OPJ_INT32 bandconst = 8192 * 8192 / ((OPJ_INT32) floor(band->stepsize * 8192));
 
 				for (precno = 0; precno < res->pw * res->ph; ++precno) {
@@ -1480,7 +1480,7 @@ OPJ_BOOL opj_t1_encode_cblks(   opj_t1_t *t1,
 
 					for (cblkno = 0; cblkno < prc->cw * prc->ch; ++cblkno) {
 						opj_tcd_cblk_enc_t* cblk = &prc->cblks.enc[cblkno];
-						OPJ_INT32* restrict tiledp;
+						OPJ_INT32* OPJ_RESTRICT tiledp;
 						OPJ_UINT32 cblk_w;
 						OPJ_UINT32 cblk_h;
 						OPJ_UINT32 i, j, tileIndex=0, tileLineAdvance;


### PR DESCRIPTION
This patch changes the 'restrict' define to 'OBJ_RESTRICT' to avoid possible future issues with the restrict keyword of Visual Studio. It also enables restrict for Visual Studio 2005 and up.