### PR TITLE
Add missing include statement for ssize_t

### DIFF
--- a/src/bin/jp2/converttif.c
+++ b/src/bin/jp2/converttif.c
@@ -42,6 +42,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 #ifndef OPJ_HAVE_LIBTIFF
 # error OPJ_HAVE_LIBTIFF_NOT_DEFINED

--- a/tests/compare_images.c
+++ b/tests/compare_images.c
@@ -37,6 +37,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <assert.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 #include "opj_apps_config.h"
 #include "opj_getopt.h"


### PR DESCRIPTION
Compilation of code which uses libtiff fails when ssize_t is undefined:

openjpeg/thirdparty/libtiff/tif_config.h:324:22:
 error: unknown type name ‘ssize_t’
 #define TIFF_SSIZE_T ssize_t
                      ^
openjpeg/thirdparty/libtiff/tiffio.h:67:9: note:
 in expansion of macro ‘TIFF_SSIZE_T’
 typedef TIFF_SSIZE_T tmsize_t;
         ^

Add the missing include statement (not for Windows
which does not provide unistd.h).

Signed-off-by: Stefan Weil <sw@weilnetz.de>