### PR TITLE
[git/2.1 regression] Fix opj_write_tile() failure when numresolutions=1

### DIFF
--- a/src/lib/openjp2/dwt.c
+++ b/src/lib/openjp2/dwt.c
@@ -409,7 +409,7 @@ static INLINE OPJ_BOOL opj_dwt_encode_procedure(opj_tcd_tilecomp_t * tilec,void 
 
 	l_data_size = opj_dwt_max_resolution( tilec->resolutions,tilec->numresolutions) * (OPJ_UINT32)sizeof(OPJ_INT32);
 	bj = (OPJ_INT32*)opj_malloc((size_t)l_data_size);
-	if (! bj) {
+	if (l_data_size != 0 && ! bj) {
 		return OPJ_FALSE;
 	}
 	i = l;

--- a/src/lib/openjp2/dwt.c
+++ b/src/lib/openjp2/dwt.c
@@ -409,6 +409,8 @@ static INLINE OPJ_BOOL opj_dwt_encode_procedure(opj_tcd_tilecomp_t * tilec,void 
 
 	l_data_size = opj_dwt_max_resolution( tilec->resolutions,tilec->numresolutions) * (OPJ_UINT32)sizeof(OPJ_INT32);
 	bj = (OPJ_INT32*)opj_malloc((size_t)l_data_size);
+	/* l_data_size is equal to 0 when numresolutions == 1 but bj is not used */
+	/* in that case, so do not error out */
 	if (l_data_size != 0 && ! bj) {
 		return OPJ_FALSE;
 	}


### PR DESCRIPTION
When trying the GDAL OpenJPEG driver against openjpeg current master HEAD,
I get failures when trying to create .jp2 files. The driver uses
opj_write_tile() and in some tests numresolutions = 1.

In openjp2/dwt.c:410, l_data_size = opj_dwt_max_resolution( tilec->resolutions,tilec->numresolutions) * (OPJ_UINT32)sizeof(OPJ_INT32);
is called and returns l_data_size = 0. Now in git opj_malloc() has a special case
for 0 to return a NULL pointer whereas previously it relied on system malloc(),
which in my case didn't return NULL.

So only test the pointer value if l_data_size != 0. This makes the GDAL
autotest suite to pass again.