### PR TITLE
Fix implementation of opj_calloc

### DIFF
--- a/src/lib/openjp2/opj_malloc.c
+++ b/src/lib/openjp2/opj_malloc.c
@@ -196,10 +196,10 @@ void * opj_malloc(size_t size)
 }
 void * opj_calloc(size_t num, size_t size)
 {
-  if (size == 0U) { /* prevent implementation defined behavior of realloc */
+  if (num == 0 || size == 0) {
+    /* prevent implementation defined behavior of realloc */
     return NULL;
   }
-  /* according to C89 standard, num == 0 shall return a valid pointer */
   return calloc(num, size);
 }
 


### PR DESCRIPTION
The parameter "size" is typically the size of some data type and should
never be 0. It is much more important to check the "num" parameter if
defined behaviour is required.

Remove also a comment which is not helpful.

Signed-off-by: Stefan Weil <sw@weilnetz.de>