### PR TITLE
[fix] Allow to convert 3/5/7/9/11/13/15 bpp JP2 files to TIF

### DIFF
--- a/src/bin/jp2/converttif.c
+++ b/src/bin/jp2/converttif.c
@@ -223,6 +223,12 @@ int imagetotif(opj_image_t * image, const char *outfile)
 		return 1;
 	}
 	
+	/* Store 3-bits input as 4-bits TIFF, 5-bits as 6-bits, etc... */
+	if ( (bps != 1) && (bps & 1) )
+	{
+		bps += 1;
+	}
+
 	if((bps > 16) || ((bps != 1) && (bps & 1))) bps = 0;
 	if(bps == 0)
 	{


### PR DESCRIPTION
This issue comes from the decompression of Sentinel-2 Earth Observation satellite products, which are currently delivered as 15-bpp JP2 files.

OpenJPEG 2.0.1 and 2.1 are affected by a serious bug when using opj_decompress to convert the JP2 files to TIF format : the actual pixels values are twice the expected values.

Current trunk simply refuses to convert the data to TIF and errors out with the message :
```
imagetotif: Bits=0, Only 1, 2, 4, 6, 8, 10, 12, 14 and 16 bits implemented
```

This commit simply considers the unsupported 3/5/7/9/11/13/15 bit-precision as if they were 4/6/8/10/12/14/16 bpp data, to at least allow TIF conversion. The bug affecting 2.0.1 and 2.1 cannot be reproduced then, and pixel values in TIF are as expected.


Please note that Kakadu does output a 15 bpp TIF :
```
$ tiffinfo S2A_OPER_MSI_L1C_TL_SGS__20151127T035842_A002245_T52SEG_B08_KDU.tif
TIFF Directory at offset 0x8 (8)
  Image Width: 10980 Image Length: 10980
  Resolution: 0.01, 0.01 (unitless)
  Bits/Sample: 15
  Sample Format: unsigned integer
  Compression Scheme: None
  Photometric Interpretation: min-is-black
  Samples/Pixel: 1
  Rows/Strip: 814
  Planar Configuration: single image plane
```

while with this fix, OpenJPEG outputs a 16bpp TIF :
```
tiffinfo S2A_OPER_MSI_L1C_TL_SGS__20151127T035842_A002245_T52SEG_B08_OPJ_TRUNK.tif
TIFF Directory at offset 0xe5f3628 (241120808)
  Image Width: 10980 Image Length: 10980
  Bits/Sample: 16
  Compression Scheme: None
  Photometric Interpretation: min-is-black
  Orientation: row 0 top, col 0 lhs
  Samples/Pixel: 1
  Rows/Strip: 1
  Planar Configuration: single image plane
```

I do have some issues with the 15bpp TIFF files in other software (namely the Java JAI TIF reader), so for my use case it is better to keep only 1, 2, 4, 6, 8, 10, 12, 14 and 16 bits TIF.