### PR TITLE
Remove dead code in opj_dump

### DIFF
--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -433,12 +433,6 @@ int main(int argc, char *argv[])
 	img_fol_t img_fol;
 	dircnt_t *dirptr = NULL;
 
-#ifdef MSD
-	OPJ_BOOL l_go_on = OPJ_TRUE;
-	OPJ_UINT32 l_max_data_size = 1000;
-	OPJ_BYTE * l_data = (OPJ_BYTE *) malloc(1000);
-#endif
-
 	/* Set decoding parameters to default values */
 	opj_set_default_decoder_parameters(&parameters);
 


### PR DESCRIPTION
The variables defined here are not used anywhere in the code, even in ifdef'd code.
They create a cppcheck warning. Better to get rid of them