### PR TITLE
Fix negative shift left reported by UBSan

### DIFF
--- a/src/lib/openjp2/t1.c
+++ b/src/lib/openjp2/t1.c
@@ -1514,7 +1514,7 @@ OPJ_BOOL opj_t1_encode_cblks(   opj_t1_t *t1,
 						if (tccp->qmfbid == 1) {
 							for (j = 0; j < cblk_h; ++j) {
 								for (i = 0; i < cblk_w; ++i) {
-									tiledp[tileIndex] <<= T1_NMSEDEC_FRACBITS;
+									tiledp[tileIndex] *= 1 << T1_NMSEDEC_FRACBITS;
 									tileIndex++;
 								}
 								tileIndex += tileLineAdvance;


### PR DESCRIPTION
As @boxerab said, this shall have no performance impact on 2’s complement machine where
the compiler generates a left shift instruction for the signed multiplication by a positive constant power of two.
Verified at least on MacOS Xcode 7.3, same assembly generated after fix.

Update #718