### PR TITLE
Fix negative shift left reported by UBSan

### DIFF
--- a/src/lib/openjp2/t1.c
+++ b/src/lib/openjp2/t1.c
@@ -1514,7 +1514,7 @@ OPJ_BOOL opj_t1_encode_cblks(   opj_t1_t *t1,
 						if (tccp->qmfbid == 1) {
 							for (j = 0; j < cblk_h; ++j) {
 								for (i = 0; i < cblk_w; ++i) {
-									tiledp[tileIndex] *= 1 << T1_NMSEDEC_FRACBITS;
+									tiledp[tileIndex] *= (1 << T1_NMSEDEC_FRACBITS);
 									tileIndex++;
 								}
 								tileIndex += tileLineAdvance;

--- a/src/lib/openjp2/tcd.c
+++ b/src/lib/openjp2/tcd.c
@@ -1911,7 +1911,7 @@ static OPJ_BOOL opj_tcd_dc_level_shift_encode ( opj_tcd_t *p_tcd )
                 }
                 else {
                         for (i = 0; i < l_nb_elem; ++i) {
-                                *l_current_ptr = (*l_current_ptr - l_tccp->m_dc_level_shift) << 11 ;
+                                *l_current_ptr = (*l_current_ptr - l_tccp->m_dc_level_shift) * (1 << 11);
                                 ++l_current_ptr;
                         }
                 }


### PR DESCRIPTION
Follow-up of #757

This shall have no performance impact on 2’s complement machine where
the compiler replaces the multiplication by power of two (constant) by
a left shift.
Verified at least on MacOS Xcode 7.3, same assembly generated after fix.

Update #718