### PR TITLE
Ignore clang's summary warning

### DIFF
--- a/cmake/CTestCustom.cmake.in
+++ b/cmake/CTestCustom.cmake.in
@@ -25,6 +25,9 @@ set(CTEST_CUSTOM_COVERAGE_EXCLUDE
 set(CTEST_CUSTOM_WARNING_EXCEPTION
   ${CTEST_CUSTOM_WARNING_EXCEPTION}
 
+  # Ignore clang's summary warning, assuming prior text has matched some
+  # other warning expression:
+  "[0-9,]+ warnings? generated."
   # Suppress warning caused by intentional messages about deprecation
   ".*warning,.* is deprecated"
   # java also warns about deprecated API


### PR DESCRIPTION
This assumes prior text has matched some other warning expression.

This reduces the warnings reported for clang build on the dashboard,
which were caused only by the "XXX warnings generated." message.
For some reason they were not reported when not using ctest launchers.

This commit allows to confidently use ctest launchers to improve
dashboard reports.