### PR TITLE
Allow using CTEST_USE_LAUNCHERS even when tests are disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,9 @@ if(BUILD_TESTING)
   endif()
 endif()
 
+# Allow the use of CTEST_USE_LAUNCHERS even when not including CTest (mingw builds)
+include(CTestUseLaunchers OPTIONAL)
+
 #-----------------------------------------------------------------------------
 # install all targets referenced as OPENJPEGTargets
 install(EXPORT OpenJPEGTargets DESTINATION ${OPENJPEG_INSTALL_PACKAGE_DIR})


### PR DESCRIPTION
Since cmake >= 3.0, using CTEST_USE_LAUNCHERS requires include(CTestUseLaunchers),
which is automatically done by include(CTest)

Setting CTEST_USE_LAUNCHERS in the cache without including CTest later
triggers a configuration error :
   CMake Error: CTEST_USE_LAUNCHERS is enabled, but the RULE_LAUNCH_COMPILE
   global property is not defined.
   Did you forget to include(CTest) in the toplevel CMakeLists.txt ?

CTEST_USE_LAUNCHERS was silently ignored in cmake <= 2.8 when not including CTest

Include CTestUseLaunchers always, so that CTEST_USE_LAUNCHERS can be used even when not
including CTest (for example for MinGW builds).
This helps presenting the build errors and warnings more cleanly on the Dashboard.