### PR TITLE
Fix dependency for pkg-config (issue #594)

### DIFF
--- a/src/lib/openjpip/libopenjpip.pc.cmake.in
+++ b/src/lib/openjpip/libopenjpip.pc.cmake.in
@@ -9,7 +9,7 @@ Name: openjpip
 Description: JPEG2000 Interactivity tools, APIs and protocols (Part 9)
 URL: http://www.openjpeg.org/
 Version: @OPENJPEG_VERSION@
-Requires: openjp2
+Requires: libopenjp2
 Libs: -L${libdir} -lopenjpip
 Libs.private: -lm -lcurl -lfcgi -lpthread
 Cflags: -I${includedir}

--- a/src/lib/openjpwl/libopenjpwl.pc.cmake.in
+++ b/src/lib/openjpwl/libopenjpwl.pc.cmake.in
@@ -9,7 +9,7 @@ Name: openjpwl
 Description: JPEG2000 Wireless library (Part 11)
 URL: http://www.openjpeg.org/
 Version: @OPENJPEG_VERSION@
-Requires: openjp2
+Requires: libopenjp2
 Libs: -L${libdir} -lopenjpwl
 Libs.private: -lm
 Cflags: -I${includedir}


### PR DESCRIPTION
openjpeg provides libopenjp2.pc, so the require statements must refer to
libopenjp2 instead of openjp2.

Signed-off-by: Stefan Weil <sw@weilnetz.de>