### PR TITLE
Add compilation test for standalone inclusion of openjpeg.h

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,8 @@ set_property(TEST rta4 APPEND PROPERTY DEPENDS tte4)
 add_test(NAME rta5 COMMAND j2k_random_tile_access tte5.j2k)
 set_property(TEST rta5 APPEND PROPERTY DEPENDS tte5)
 
+add_executable(include_openjpeg include_openjpeg.c)
+
 # No image send to the dashboard if lib PNG is not available.
 if(NOT OPJ_HAVE_LIBPNG)
   message(WARNING "Lib PNG seems to be not available: if you want run the non-regression tests with images reported to the dashboard, you need it (try BUILD_THIRDPARTY)")

--- a/tests/include_openjpeg.c
+++ b/tests/include_openjpeg.c
@@ -1,0 +1,9 @@
+#include <openjpeg.h>
+
+int main(int argc, char **argv)
+{
+	(void)argc;
+	(void)argv;
+	
+	return 0;
+}


### PR DESCRIPTION
This ensures all openjpeg.h dependencies are met.
Update uclouvain/openjpeg#673