### PR TITLE
Implement predictive termination check

### DIFF
--- a/src/lib/openjp2/mqc.c
+++ b/src/lib/openjp2/mqc.c
@@ -300,6 +300,7 @@ void opj_mqc_init_enc(opj_mqc_t *mqc, OPJ_BYTE *bp)
     assert(*(mqc->bp) != 0xff);
 
     mqc->start = bp;
+    mqc->end_of_byte_stream_counter = 0;
 }
 
 void opj_mqc_encode(opj_mqc_t *mqc, OPJ_UINT32 d)
@@ -513,6 +514,7 @@ void opj_mqc_init_dec(opj_mqc_t *mqc, OPJ_BYTE *bp, OPJ_UINT32 len,
     /* See https://github.com/uclouvain/openjpeg/issues/921 */
     opj_mqc_init_dec_common(mqc, bp, len, extra_writable_bytes);
     opj_mqc_setcurctx(mqc, 0);
+    mqc->end_of_byte_stream_counter = 0;
     if (len == 0) {
         mqc->c = 0xff << 16;
     } else {

--- a/src/lib/openjp2/mqc.h
+++ b/src/lib/openjp2/mqc.h
@@ -78,6 +78,8 @@ typedef struct opj_mqc {
     OPJ_UINT32 a;
     /** number of bits already read or free to write */
     OPJ_UINT32 ct;
+    /* only used by decoder, to count the number of times a terminating 0xFF >0x8F marker is read */
+    OPJ_UINT32 end_of_byte_stream_counter;
     /** pointer to the current position in the buffer */
     OPJ_BYTE *bp;
     /** pointer to the start of the buffer */

--- a/src/lib/openjp2/mqc_inl.h
+++ b/src/lib/openjp2/mqc_inl.h
@@ -109,6 +109,7 @@ static INLINE OPJ_UINT32 opj_mqc_raw_decode(opj_mqc_t *mqc)
             if (l_c > 0x8f) { \
                 c += 0xff00; \
                 ct = 8; \
+                mqc->end_of_byte_stream_counter ++; \
             } else { \
                 mqc->bp++; \
                 c += l_c << 9; \

--- a/src/lib/openjp2/t1.h
+++ b/src/lib/openjp2/t1.h
@@ -230,7 +230,10 @@ Decode the code-blocks of a tile
 void opj_t1_decode_cblks(opj_thread_pool_t* tp,
                          volatile OPJ_BOOL* pret,
                          opj_tcd_tilecomp_t* tilec,
-                         opj_tccp_t* tccp);
+                         opj_tccp_t* tccp,
+                         opj_event_mgr_t *p_manager,
+                         opj_mutex_t* p_manager_mutex,
+                         OPJ_BOOL check_pterm);
 
 
 


### PR DESCRIPTION
This implements (on top of https://github.com/uclouvain/openjpeg/pull/786) checking of code stream errors when predictable termination is enabled. Warning are emitted when errors are found. To be honest,  I came with the numerical values used by those checks in a rather experimental way by running it on a set of good and corrupted images.

The relevant commit is https://github.com/uclouvain/openjpeg/pull/800/commits/c9f3d8865c4362d32047d11f5585af286f650cd4
