### PR TITLE
fixes opjviewer build

### DIFF
--- a/src/bin/wx/OPJViewer/CMakeLists.txt
+++ b/src/bin/wx/OPJViewer/CMakeLists.txt
@@ -4,17 +4,13 @@ find_package(wxWidgets REQUIRED)
 include(${wxWidgets_USE_FILE})
 
 include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}/../..
-  ${CMAKE_CURRENT_SOURCE_DIR}/..
   ${OPENJPEG_SOURCE_DIR}/src/lib
   ${OPENJPEG_SOURCE_DIR}/src/bin
   ${OPENJPEG_SOURCE_DIR}/src/lib/openjp2
   ${OPENJPEG_BINARY_DIR}/src/lib/openjp2 # opj_config.h and opj_config_private.h
   )
 
-# original flags:
-# -DUSE_JPWL -DwxUSE_LIBOPENJPEG -DwxUSE_GUI=1 -DOPJ_STATIC -DOPJ_HTMLABOUT -DOPJ_INICONFIG -DUSE_JPSEC -DOPJ_MANYFORMATS
-add_definitions(-DwxUSE_LIBOPENJPEG -DOPENJPEG_VERSION="1.5.0")
+add_definitions(-DwxUSE_LIBOPENJPEG -DOPENJPEG_VERSION="${OPENJPEG_VERSION}")
 set(OPJV_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/source/imagjpeg2000.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/source/wxj2kparser.cpp

--- a/src/bin/wx/OPJViewer/source/OPJViewer.h
+++ b/src/bin/wx/OPJViewer/source/OPJViewer.h
@@ -106,8 +106,6 @@
 #include "wx/toolbar.h"
 #include "wx/artprov.h"
 
-#include "openjp2/openjpeg.h"
-
 //#include "imagj2k.h"
 //#include "imagjp2.h"
 //#include "imagmj2.h"

--- a/src/bin/wx/OPJViewer/source/imagjpeg2000.cpp
+++ b/src/bin/wx/OPJViewer/source/imagjpeg2000.cpp
@@ -56,8 +56,6 @@
     #include "wx/module.h"
 #endif
 
-#include "openjp2/openjpeg.h"
-
 #include "wx/filefn.h"
 #include "wx/wfstream.h"
 

--- a/src/bin/wx/OPJViewer/source/imagjpeg2000.h
+++ b/src/bin/wx/OPJViewer/source/imagjpeg2000.h
@@ -49,7 +49,8 @@
 #if wxUSE_LIBOPENJPEG
 
 #include "wx/image.h"
-#include "openjp2/openjpeg.h"
+#include "openmj2/openjpeg.h"
+#include "openmj2/event.h"
 #include "jp2/index.h"
 
 #define wxBITMAP_TYPE_JPEG2000	50


### PR DESCRIPTION
These were the minimum changes necessary to get the opjviewer project to build. There are definitely issues with crashing, but at least this gets the ball rolling so someone with more wxwindows experience can take a look.

My build command:

mkdir build
cd build
cmake -DBUILD_MJ2=ON -DBUILD_JPWL=ON -DBUILD_VIEWER=ON -DCMAKE_VERBOSE_MAKEFILE=TRUE -DCMAKE_BUILD_TYPE=Debug ..