### PR TITLE
Bit fields type

### DIFF
--- a/src/lib/openjp2/j2k.h
+++ b/src/lib/openjp2/j2k.h
@@ -228,7 +228,7 @@ typedef struct opj_simple_mcc_decorrelation_data
 	OPJ_UINT32			 m_nb_comps;
 	opj_mct_data_t *	 m_decorrelation_array;
 	opj_mct_data_t *	 m_offset_array;
-	OPJ_UINT32			 m_is_irreversible : 1;
+	OPJ_BITFIELD		 m_is_irreversible : 1;
 }
 opj_simple_mcc_decorrelation_data_t;
 
@@ -306,11 +306,11 @@ typedef struct opj_tcp
 
 	/***** FLAGS *******/
 	/** If cod == 1 --> there was a COD marker for the present tile */
-	OPJ_UINT32 cod : 1;
+	OPJ_BITFIELD cod : 1;
 	/** If ppt == 1 --> there was a PPT marker for the present tile */
-	OPJ_UINT32 ppt : 1;
+	OPJ_BITFIELD ppt : 1;
 	/** indicates if a POC marker has been used O:NO, 1:YES */
-	OPJ_UINT32 POC : 1;
+	OPJ_BITFIELD POC : 1;
 } opj_tcp_t;
 
 
@@ -327,13 +327,13 @@ typedef struct opj_encoding_param
 	/** Flag determining tile part generation*/
 	OPJ_BYTE m_tp_flag;
 	/** allocation by rate/distortion */
-	OPJ_UINT32 m_disto_alloc : 1;
+	OPJ_BITFIELD m_disto_alloc : 1;
 	/** allocation by fixed layer */
-	OPJ_UINT32 m_fixed_alloc : 1;
+	OPJ_BITFIELD m_fixed_alloc : 1;
 	/** add fixed_quality */
-	OPJ_UINT32 m_fixed_quality : 1;
+	OPJ_BITFIELD m_fixed_quality : 1;
 	/** Enabling Tile part generation*/
-	OPJ_UINT32 m_tp_on : 1;
+	OPJ_BITFIELD m_tp_on : 1;
 }
 opj_encoding_param_t;
 
@@ -453,9 +453,9 @@ typedef struct opj_cp
 
 	/******** FLAGS *********/
 	/** if ppm == 1 --> there was a PPM marker*/
-	OPJ_UINT32 ppm : 1;
+	OPJ_BITFIELD ppm : 1;
 	/** tells if the parameter is a coding or decoding one */
-	OPJ_UINT32 m_is_decoder : 1;
+	OPJ_BITFIELD m_is_decoder : 1;
 /* <<UniPG */
 } opj_cp_t;
 
@@ -497,12 +497,12 @@ typedef struct opj_j2k_dec
 	 */
 	OPJ_BOOL   m_last_tile_part;
 	/** to tell that a tile can be decoded. */
-	OPJ_UINT32 m_can_decode			: 1;
-	OPJ_UINT32 m_discard_tiles		: 1;
-	OPJ_UINT32 m_skip_data			: 1;
+	OPJ_BITFIELD m_can_decode	  : 1;
+	OPJ_BITFIELD m_discard_tiles  : 1;
+	OPJ_BITFIELD m_skip_data	  : 1;
 	/** TNsot correction : see issue 254 **/
-	OPJ_UINT32 m_nb_tile_parts_correction_checked : 1;
-	OPJ_UINT32 m_nb_tile_parts_correction : 1;
+	OPJ_BITFIELD m_nb_tile_parts_correction_checked : 1;
+	OPJ_BITFIELD m_nb_tile_parts_correction : 1;
 
 } opj_j2k_dec_t;
 

--- a/src/lib/openjp2/j2k.h
+++ b/src/lib/openjp2/j2k.h
@@ -497,9 +497,9 @@ typedef struct opj_j2k_dec
 	 */
 	OPJ_BOOL   m_last_tile_part;
 	/** to tell that a tile can be decoded. */
-	OPJ_BITFIELD m_can_decode	  : 1;
-	OPJ_BITFIELD m_discard_tiles  : 1;
-	OPJ_BITFIELD m_skip_data	  : 1;
+	OPJ_BITFIELD m_can_decode : 1;
+	OPJ_BITFIELD m_discard_tiles : 1;
+	OPJ_BITFIELD m_skip_data : 1;
 	/** TNsot correction : see issue 254 **/
 	OPJ_BITFIELD m_nb_tile_parts_correction_checked : 1;
 	OPJ_BITFIELD m_nb_tile_parts_correction : 1;

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -129,8 +129,6 @@ typedef uint64_t OPJ_UINT64;
 
 typedef int64_t  OPJ_OFF_T; /* 64-bit file offset type */
 
-typedef unsigned int OPJ_BITFIELD;
-
 #include <stdio.h>
 typedef size_t   OPJ_SIZE_T;
 

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -129,6 +129,8 @@ typedef uint64_t OPJ_UINT64;
 
 typedef int64_t  OPJ_OFF_T; /* 64-bit file offset type */
 
+typedef unsigned int OPJ_BITFIELD;
+
 #include <stdio.h>
 typedef size_t   OPJ_SIZE_T;
 

--- a/src/lib/openjp2/opj_includes.h
+++ b/src/lib/openjp2/opj_includes.h
@@ -183,6 +183,9 @@ static INLINE long opj_lrintf(float f) {
 #	pragma intrinsic(__emul)
 #endif
 
+/* Type to use for bit-fields in internal headers */
+typedef unsigned int OPJ_BITFIELD;
+
 #include "opj_inttypes.h"
 #include "opj_clock.h"
 #include "opj_malloc.h"

--- a/src/lib/openjp2/tcd.h
+++ b/src/lib/openjp2/tcd.h
@@ -70,7 +70,7 @@ typedef struct opj_tcd_pass {
 	OPJ_UINT32 rate;
 	OPJ_FLOAT64 distortiondec;
 	OPJ_UINT32 len;
-	OPJ_UINT32 term : 1;
+	OPJ_BITFIELD term : 1;
 } opj_tcd_pass_t;
 
 /**
@@ -219,7 +219,7 @@ typedef struct opj_tcd
 	/** current encoded/decoded tile */
 	OPJ_UINT32 tcd_tileno;
 	/** tell if the tcd is a decoder. */
-	OPJ_UINT32 m_is_decoder : 1;
+	OPJ_BITFIELD m_is_decoder : 1;
 } opj_tcd_t;
 
 /** @name Exported functions */


### PR DESCRIPTION
The definition of bit-fields with type OPJ_UINT32 caused compilation errors
on IBM iSeries, because OPJ_UINT32 is defined as uint32_t, and
uint32_t is defined as unsigned long in `<stdint.h>` on IBM iSeries:

    228       |typedef struct opj_simple_mcc_decorrelation_data                                                  
    229       |{                                                                                                
    230       | OPJ_UINT32    m_index;                                                                          
    231       | OPJ_UINT32    m_nb_comps;                                                                       
    232       | opj_mct_data_t *  m_decorrelation_array;                                                        
    233       | opj_mct_data_t *  m_offset_array;                                                               
    234       | OPJ_UINT32    m_is_irreversible : 1;                                                            
    ==========> .........................................a........................................................
    =SEVERE==========> a - CZM0009  Bit field m_is_irreversible must be of type signed int, unsigned int or int. 
    235       |}  

The definition of bit-fields with an integer type of  a specific size doesn't make sense anyway. Therefore I introduced a new typedef `OPJ_BITFIELD` defined as `unsigned int`, and changed all bit-fields in structures to use this typedef.