### PR TITLE
Reenable clang-3.9 build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
         apt:
           sources:
             - llvm-toolchain-precise
+            - ubuntu-toolchain-r-test
           packages:
             - clang-3.9
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,15 @@ matrix:
       compiler: clang
       env: OPJ_CI_ARCH=x86_64 OPJ_CI_BUILD_CONFIGURATION=Debug OPJ_CI_ASAN=1
     - os: linux
+      compiler: clang-3.9
+      env: OPJ_CI_ARCH=x86_64 OPJ_CI_BUILD_CONFIGURATION=Release
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-precise
+          packages:
+            - clang-3.9
+    - os: linux
       compiler: x86_64-w64-mingw32-gcc
       env: OPJ_CI_ARCH=x86_64 OPJ_CI_BUILD_CONFIGURATION=Release
       addons:

--- a/tools/travis-ci/install.sh
+++ b/tools/travis-ci/install.sh
@@ -115,33 +115,3 @@ if [ "${OPJ_CI_SKIP_TESTS:-}" != "1" ]; then
 		fi
 	fi
 fi
-
-# Install clang if necessary.
-# clang-3.4 is available on base image
-# For more up-to-date versions, use packages from http://llvm.org/apt
-# Cannot use addons.apt.packages because clang-3.9 is currently on hold
-# (see https://github.com/travis-ci/apt-package-whitelist/pull/2780 or https://github.com/travis-ci/apt-package-whitelist/pull/2770)
-# "sudo: required" should be set in .travis.yml matrix for those configurations
-if echo "${CC:-}" | egrep -q "^clang-3.[7-9]?$" ; then
-  case "${CC:-}" in
-  clang-3.7)
-    echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-    ;;
-  clang-3.8)
-    echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.8 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-    ;;
-  clang-3.9)
-    echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise main" | sudo tee /etc/apt/sources.list.d/llvm.list
-    ;;
-  *)
-    echo "We should never have been there. Exiting..."
-    exit 1
-  esac
-  wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-
-  # On precise, ubuntu-toolchain ppa must be installed also (see http://llvm.org/apt)
-  sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-
-  sudo apt-get update -qq
-  sudo apt-get install "${CC:-}" -y
-fi


### PR DESCRIPTION
Seems clang is back online & now available through apt add-on 
If the PR passes test, this will be confirmed.