### PR TITLE
Fix an integer overflow issue

### DIFF
--- a/src/lib/openjp2/pi.c
+++ b/src/lib/openjp2/pi.c
@@ -36,6 +36,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <limits.h>
 #include "opj_includes.h"
 
 /** @defgroup PI PI - Implementation of a packet iterator */
@@ -1237,7 +1238,13 @@ opj_pi_iterator_t *opj_pi_create_decode(opj_image_t *p_image,
 	l_current_pi = l_pi;
 
 	/* memory allocation for include */
-	l_current_pi->include = (OPJ_INT16*) opj_calloc((l_tcp->numlayers +1) * l_step_l, sizeof(OPJ_INT16));
+	/* prevent an integer overflow issue */
+	l_current_pi->include = 00;
+	if (l_step_l && l_tcp->numlayers < UINT_MAX / l_step_l - 1)
+	{
+		l_current_pi->include = (OPJ_INT16*) opj_calloc((l_tcp->numlayers +1) * l_step_l, sizeof(OPJ_INT16));
+	}
+
 	if
 		(!l_current_pi->include)
 	{

--- a/src/lib/openjp2/pi.c
+++ b/src/lib/openjp2/pi.c
@@ -1240,7 +1240,7 @@ opj_pi_iterator_t *opj_pi_create_decode(opj_image_t *p_image,
 	/* memory allocation for include */
 	/* prevent an integer overflow issue */
 	l_current_pi->include = 00;
-	if (l_step_l && l_tcp->numlayers < UINT_MAX / l_step_l - 1)
+	if (l_step_l && l_tcp->numlayers < UINT_MAX / sizeof(OPJ_INT16) / l_step_l - 1)
 	{
 		l_current_pi->include = (OPJ_INT16*) opj_calloc((l_tcp->numlayers +1) * l_step_l, sizeof(OPJ_INT16));
 	}

--- a/src/lib/openjp2/pi.c
+++ b/src/lib/openjp2/pi.c
@@ -36,7 +36,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <limits.h>
 #include "opj_includes.h"
 
 /** @defgroup PI PI - Implementation of a packet iterator */
@@ -1240,7 +1239,7 @@ opj_pi_iterator_t *opj_pi_create_decode(opj_image_t *p_image,
 	/* memory allocation for include */
 	/* prevent an integer overflow issue */
 	l_current_pi->include = 00;
-	if (l_step_l && l_tcp->numlayers < UINT_MAX / sizeof(OPJ_INT16) / l_step_l - 1)
+	if (l_step_l && l_tcp->numlayers < ((OPJ_UINT32)-1) / sizeof(OPJ_INT16) / l_step_l - 1)
 	{
 		l_current_pi->include = (OPJ_INT16*) opj_calloc((l_tcp->numlayers +1) * l_step_l, sizeof(OPJ_INT16));
 	}

--- a/src/lib/openjp2/pi.c
+++ b/src/lib/openjp2/pi.c
@@ -1239,7 +1239,7 @@ opj_pi_iterator_t *opj_pi_create_decode(opj_image_t *p_image,
 	/* memory allocation for include */
 	/* prevent an integer overflow issue */
 	l_current_pi->include = 00;
-	if (l_step_l && l_tcp->numlayers < ((SIZE_MAX)-1) / sizeof(OPJ_INT16) / l_step_l - 1)
+	if (l_step_l <= (SIZE_MAX / (l_tcp->numlayers + 1U)))
 	{
 		l_current_pi->include = (OPJ_INT16*) opj_calloc((l_tcp->numlayers +1) * l_step_l, sizeof(OPJ_INT16));
 	}

--- a/src/lib/openjp2/pi.c
+++ b/src/lib/openjp2/pi.c
@@ -1239,7 +1239,7 @@ opj_pi_iterator_t *opj_pi_create_decode(opj_image_t *p_image,
 	/* memory allocation for include */
 	/* prevent an integer overflow issue */
 	l_current_pi->include = 00;
-	if (l_step_l && l_tcp->numlayers < ((OPJ_UINT32)-1) / sizeof(OPJ_INT16) / l_step_l - 1)
+	if (l_step_l && l_tcp->numlayers < ((SIZE_MAX)-1) / sizeof(OPJ_INT16) / l_step_l - 1)
 	{
 		l_current_pi->include = (OPJ_INT16*) opj_calloc((l_tcp->numlayers +1) * l_step_l, sizeof(OPJ_INT16));
 	}


### PR DESCRIPTION
Prevent an integer overflow issue in function opj_pi_create_decode of
pi.c.

Hi, I found an integer overflow issue which could lead to OOB read and OOB write. I'd like to submit the proof-of-concept file and vulnerability report privately. Please give me an email address to report this issue. Thanks.

Regards,
Ke Liu of Tencent's Xuanwu LAB