### PR TITLE
Switch to clang 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,15 @@ matrix:
       compiler: clang
       env: OPJ_CI_ARCH=x86_64 OPJ_CI_BUILD_CONFIGURATION=Debug OPJ_CI_ASAN=1
     - os: linux
-      compiler: clang-3.9
+      compiler: clang-3.8
       env: OPJ_CI_ARCH=x86_64 OPJ_CI_BUILD_CONFIGURATION=Release
       addons:
         apt:
           sources:
-            - llvm-toolchain-precise
+            - llvm-toolchain-precise-3.8
             - ubuntu-toolchain-r-test
           packages:
-            - clang-3.9
+            - clang-3.8
     - os: linux
       compiler: x86_64-w64-mingw32-gcc
       env: OPJ_CI_ARCH=x86_64 OPJ_CI_BUILD_CONFIGURATION=Release


### PR DESCRIPTION
clang 3.9 is currently unavailable for precise through apt