### PR TITLE
Add sanity check for tile coordinates

### DIFF
--- a/src/lib/openjp2/tcd.c
+++ b/src/lib/openjp2/tcd.c
@@ -696,9 +696,20 @@ static INLINE OPJ_BOOL opj_tcd_init_tile(opj_tcd_t *p_tcd, OPJ_UINT32 p_tile_no,
 	l_tx0 = l_cp->tx0 + p * l_cp->tdx; /* can't be greater than l_image->x1 so won't overflow */
 	l_tile->x0 = (OPJ_INT32)opj_uint_max(l_tx0, l_image->x0);
 	l_tile->x1 = (OPJ_INT32)opj_uint_min(opj_uint_adds(l_tx0, l_cp->tdx), l_image->x1);
+	/* all those OPJ_UINT32 are casted to OPJ_INT32, let's do some sanity check */
+	if ((l_tile->x0 < 0) || (l_tile->x1 <= l_tile->x0)) {
+		opj_event_msg(manager, EVT_ERROR, "Tile X coordinates are not supported\n");
+		return OPJ_FALSE;
+	}
 	l_ty0 = l_cp->ty0 + q * l_cp->tdy; /* can't be greater than l_image->y1 so won't overflow */
 	l_tile->y0 = (OPJ_INT32)opj_uint_max(l_ty0, l_image->y0);
 	l_tile->y1 = (OPJ_INT32)opj_uint_min(opj_uint_adds(l_ty0, l_cp->tdy), l_image->y1);
+	/* all those OPJ_UINT32 are casted to OPJ_INT32, let's do some sanity check */
+	if ((l_tile->y0 < 0) || (l_tile->y1 <= l_tile->y0)) {
+		opj_event_msg(manager, EVT_ERROR, "Tile Y coordinates are not supported\n");
+		return OPJ_FALSE;
+	}
+	
 
 	/* testcase 1888.pdf.asan.35.988 */
 	if (l_tccp->numresolutions == 0) {

--- a/tests/compare_dump_files.c
+++ b/tests/compare_dump_files.c
@@ -118,10 +118,10 @@ int main(int argc, char **argv)
   test_cmp_parameters inParam;
   FILE *fbase=NULL, *ftest=NULL;
   int same = 0;
-  char lbase[256];
-  char strbase[256];
-  char ltest[256];
-  char strtest[256];
+  char lbase[512];
+  char strbase[512];
+  char ltest[512];
+  char strtest[512];
 
   if( parse_cmdline_cmp(argc, argv, &inParam) == 1 )
     {
@@ -154,9 +154,9 @@ int main(int argc, char **argv)
 
   while (fgets(lbase, sizeof(lbase), fbase) && fgets(ltest,sizeof(ltest),ftest))
     {
-    int nbase = sscanf(lbase, "%255[^\r\n]", strbase);
-    int ntest = sscanf(ltest, "%255[^\r\n]", strtest);
-    assert( nbase != 255 && ntest != 255 );
+    int nbase = sscanf(lbase, "%511[^\r\n]", strbase);
+    int ntest = sscanf(ltest, "%511[^\r\n]", strtest);
+    assert( nbase != 511 && ntest != 511 );
     if( nbase != 1 || ntest != 1 )
       {
       fprintf(stderr, "could not parse line from files\n" );

--- a/tests/nonregression/test_suite.ctest.in
+++ b/tests/nonregression/test_suite.ctest.in
@@ -566,3 +566,6 @@ opj_decompress -i @INPUT_NR_PATH@/issue726.j2k -o @TEMP_PATH@/issue726.png
 !opj_decompress -i @INPUT_NR_PATH@/issue775-2.j2k -o @TEMP_PATH@/issue775-2.png
 # issue 818
 opj_decompress -i @INPUT_NR_PATH@/issue818.jp2 -o @TEMP_PATH@/issue818.png
+# issue 822
+!opj_decompress -i @INPUT_NR_PATH@/issue822.jp2 -o @TEMP_PATH@/issue822.png
+

--- a/tests/nonregression/test_suite.ctest.in
+++ b/tests/nonregression/test_suite.ctest.in
@@ -566,6 +566,6 @@ opj_decompress -i @INPUT_NR_PATH@/issue726.j2k -o @TEMP_PATH@/issue726.png
 !opj_decompress -i @INPUT_NR_PATH@/issue775-2.j2k -o @TEMP_PATH@/issue775-2.png
 # issue 818
 opj_decompress -i @INPUT_NR_PATH@/issue818.jp2 -o @TEMP_PATH@/issue818.png
-# issue 822
+# issue 823 (yes, not a typo, test image is issue822)
 !opj_decompress -i @INPUT_NR_PATH@/issue822.jp2 -o @TEMP_PATH@/issue822.png
 


### PR DESCRIPTION
Coordinates are casted from OPJ_UINT32 to OPJ_INT32
Add sanity check for negative values and upper bound becoming lower
than lower bound.
See also
https://pdfium.googlesource.com/pdfium/+/b6befb2ed2485a3805cddea86dc7574510178ea9