### PR TITLE
Fix lcms2 static linking using pgk config

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -113,12 +113,19 @@ if( BUILD_THIRDPARTY)
   set(OPJ_HAVE_LIBLCMS2 1 PARENT_SCOPE)
 else(BUILD_THIRDPARTY)
   find_package(LCMS2)
+  # Static only build:
+  #   it is necessary to invoke pkg_check_module on lcms2 since it may have
+  #   several other dependencies not declared by its cmake module, but they are
+  #   in the its pkgconfig module.
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_LCMS2 QUIET lcms2)
+  endif(PKG_CONFIG_FOUND)
   if(LCMS2_FOUND)
     message(STATUS "Your system seems to have a LCMS2 lib available, we will use it")
     set(OPJ_HAVE_LCMS2_H 1 PARENT_SCOPE)
     set(OPJ_HAVE_LIBLCMS2 1 PARENT_SCOPE)
-    set(LCMS_LIBNAME ${LCMS2_LIBRARIES} PARENT_SCOPE)
-    set(LCMS_INCLUDE_DIRNAME ${LCMS2_INCLUDE_DIRS} PARENT_SCOPE)
+    set(LCMS_LIBNAME ${LCMS2_LIBRARIES} ${PC_LCMS2_STATIC_LIBRARIES} PARENT_SCOPE)
+    set(LCMS_INCLUDE_DIRNAME ${LCMS2_INCLUDE_DIRS} ${PC_LCMS2_STATIC_INCLUDE_DIRS} PARENT_SCOPE)
   else(LCMS2_FOUND) # not found lcms2
     # try to find LCMS
     find_package(LCMS)


### PR DESCRIPTION
thirdparty: lcms2: append flags found by pkg-config if available
    
This change allows to get all required CFLAGS/LDFLAGS in case of static only
build.
    
Fixes a buildroot build failure (see [1], [2] and [3]).
    
[1] http://autobuild.buildroot.net/results/5ce/5cee20afd8bef5268832cddcb3a5270746be7a57
[2] http://lists.busybox.net/pipermail/buildroot/2016-November/177187.html
[3] http://lists.busybox.net/pipermail/buildroot/2016-November/177188.html
    
Signed-off-by: Peter Seiderer <ps.report@gmx.net>
---
Depends on https://github.com/uclouvain/openjpeg/pull/866
