### PR TITLE
Remove warnings related to empty tag-trees.

### DIFF
--- a/src/lib/openjp2/tcd.c
+++ b/src/lib/openjp2/tcd.c
@@ -987,21 +987,11 @@ static INLINE OPJ_BOOL opj_tcd_init_tile(opj_tcd_t *p_tcd, OPJ_UINT32 p_tile_no,
 						l_current_precinct->incltree = opj_tgt_init(l_current_precinct->incltree, l_current_precinct->cw, l_current_precinct->ch, manager);
 					}
 
-					if (! l_current_precinct->incltree)     {
-						opj_event_msg(manager, EVT_WARNING, "No incltree created.\n");
-						/*return OPJ_FALSE;*/
-					}
-
 					if (! l_current_precinct->imsbtree) {
 						l_current_precinct->imsbtree = opj_tgt_create(l_current_precinct->cw, l_current_precinct->ch, manager);
 					}
 					else {
 						l_current_precinct->imsbtree = opj_tgt_init(l_current_precinct->imsbtree, l_current_precinct->cw, l_current_precinct->ch, manager);
-					}
-
-					if (! l_current_precinct->imsbtree) {
-						opj_event_msg(manager, EVT_WARNING, "No imsbtree created.\n");
-						/*return OPJ_FALSE;*/
 					}
 
 					for (cblkno = 0; cblkno < l_nb_code_blocks; ++cblkno) {

--- a/src/lib/openjp2/tgt.c
+++ b/src/lib/openjp2/tgt.c
@@ -81,7 +81,6 @@ opj_tgt_tree_t *opj_tgt_create(OPJ_UINT32 numleafsh, OPJ_UINT32 numleafsv, opj_e
         /* ADD */
         if (tree->numnodes == 0) {
                 opj_free(tree);
-                opj_event_msg(manager, EVT_WARNING, "tgt_create tree->numnodes == 0, no tree created.\n");
                 return 00;
         }
 


### PR DESCRIPTION
Decoding some valid .jp2 files like Sentinel2 datasets leads to warnings like:
No incltree created.
tgt_create tree->numnodes == 0, no tree created.
No imsbtree created.
tgt_create tree->numnodes == 0, no tree created.

Besides that, the image is correctly decoded. So there is no reason to emit
those warnings.