### PR TITLE
fixed uninitialised memory access, mitigated BYPASS/RESTART issues

### DIFF
--- a/src/lib/openjp2/mqc.c
+++ b/src/lib/openjp2/mqc.c
@@ -324,10 +324,12 @@ void opj_mqc_flush(opj_mqc_t *mqc) {
 	
 	if (*mqc->bp != 0xff) {
 		mqc->bp++;
+		*mqc->bp = 0;
 	}
 }
 
 void opj_mqc_bypass_init_enc(opj_mqc_t *mqc) {
+	opj_mqc_byteout(mqc);
 	mqc->c = 0;
 	mqc->ct = 8;
 	/*if (*mqc->bp == 0xff) {
@@ -362,6 +364,8 @@ OPJ_UINT32 opj_mqc_bypass_flush_enc(opj_mqc_t *mqc) {
 		}
 		mqc->bp++;
 		*mqc->bp = (OPJ_BYTE)mqc->c;
+		mqc->bp++;
+		*mqc->bp = 0;
 		mqc->ct = 8;
 		mqc->c = 0;
 	}

--- a/src/lib/openjp2/mqc.h
+++ b/src/lib/openjp2/mqc.h
@@ -65,12 +65,18 @@ typedef struct opj_mqc_state {
 
 #define MQC_NUMCTXS 19
 
+// enable impl. according to the book "JPEG2000: Image Compression Fundamentals, Standards and Practice"
+// #define BOOK_ENABLE
+
 /**
 MQ coder
 */
 typedef struct opj_mqc {
 	OPJ_UINT32 c;
 	OPJ_UINT32 a;
+#ifdef BOOK_ENABLE
+	OPJ_BYTE b;
+#endif
 	OPJ_UINT32 ct;
 	OPJ_BYTE *bp;
 	OPJ_BYTE *start;

--- a/src/lib/openjp2/t1.c
+++ b/src/lib/openjp2/t1.c
@@ -2107,6 +2107,9 @@ static void opj_t1_encode_cblk(opj_t1_t *t1,
 				/* correction = mqc_bypass_flush_enc(); */
 			} else {			/* correction = mqc_restart_enc(); */
 				opj_mqc_flush(mqc);
+#ifdef BOOK_ENABLE
+				opj_mqc_flush(mqc);
+#endif
 				correction = 1;
 			}
 			pass->term = 1;
@@ -2132,7 +2135,7 @@ static void opj_t1_encode_cblk(opj_t1_t *t1,
 			bpno--;
 		}
 
-		if (pass->term && bpno > 0) {
+		if (pass->term && (bpno > 0 || (bpno == 0 && passtype < 2))) {
 			type = ((bpno < ((OPJ_INT32) (cblk->numbps) - 4)) && (passtype < 2) && (cblksty & J2K_CCP_CBLKSTY_LAZY)) ? T1_TYPE_RAW : T1_TYPE_MQ;
 			if (type == T1_TYPE_RAW)
 				opj_mqc_bypass_init_enc(mqc);

--- a/src/lib/openjp2/t1.c
+++ b/src/lib/openjp2/t1.c
@@ -2102,7 +2102,7 @@ static void opj_t1_encode_cblk(opj_t1_t *t1,
 		/* Code switch "RESTART" (i.e. TERMALL) */
 		if ((cblksty & J2K_CCP_CBLKSTY_TERMALL)	&& !((passtype == 2) && (bpno - 1 < 0))) {
 			if (type == T1_TYPE_RAW) {
-				opj_mqc_flush(mqc);
+				opj_mqc_bypass_flush_enc(mqc);
 				correction = 1;
 				/* correction = mqc_bypass_flush_enc(); */
 			} else {			/* correction = mqc_restart_enc(); */
@@ -2114,7 +2114,7 @@ static void opj_t1_encode_cblk(opj_t1_t *t1,
 			if (((bpno < ((OPJ_INT32) (cblk->numbps) - 4) && (passtype > 0))
 				|| ((bpno == ((OPJ_INT32)cblk->numbps - 4)) && (passtype == 2))) && (cblksty & J2K_CCP_CBLKSTY_LAZY)) {
 				if (type == T1_TYPE_RAW) {
-					opj_mqc_flush(mqc);
+					opj_mqc_bypass_flush_enc(mqc);
 					correction = 1;
 					/* correction = mqc_bypass_flush_enc(); */
 				} else {		/* correction = mqc_restart_enc(); */


### PR DESCRIPTION
cf. issues #612 #674 #209
This patch fixes uninitialised memory access caused by advancing a pointer in MQ coder. It also fixes BYPASS mode initialization and flush.