### PR TITLE
Remove spurious .R macros from manpages

### DIFF
--- a/doc/man/man1/opj_compress.1
+++ b/doc/man/man1/opj_compress.1
@@ -49,7 +49,7 @@ Valid output image extensions are
 .P
 .B opj_compress \-h \fRPrint a help message and exit.
 .P
-.R See JPWL OPTIONS for special options
+See JPWL OPTIONS for special options
 .SH OPTIONS
 .TP
 .B \-\^b " n,n"

--- a/doc/man/man1/opj_decompress.1
+++ b/doc/man/man1/opj_decompress.1
@@ -49,7 +49,7 @@ Valid output image extensions are
 .P
 .B opj_decompress \-h  \fRPrint help message and exit
 .P
-.R See JPWL OPTIONS for special options
+See JPWL OPTIONS for special options
 .SH OPTIONS
 .TP
 .B \-\^i "name"


### PR DESCRIPTION
Fixes the following warnings from `man`:
```
`R' is a string (producing the registered sign), not a macro.
```