### PR TITLE
Add profiling of CPU and memory usage (#912)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,11 @@ matrix:
             - gcc-multilib
     - os: linux
       compiler: gcc
-      env: OPJ_CI_ARCH=x86_64 OPJ_CI_BUILD_CONFIGURATION=Debug
+      env: OPJ_CI_ARCH=x86_64 OPJ_CI_BUILD_CONFIGURATION=Debug OPJ_CI_PROFILE=1
+      addons:
+        apt:
+          packages:
+            - valgrind
     - os: linux
       compiler: clang
       env: OPJ_CI_ARCH=x86_64 OPJ_CI_BUILD_CONFIGURATION=Debug OPJ_CI_ASAN=1

--- a/tests/profiling/filter_massif_output.py
+++ b/tests/profiling/filter_massif_output.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017, IntoPIX SA
+# Contact: support@intopix.com
+# Author: Even Rouault
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS `AS IS'
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+import sys
+
+lines = open(sys.argv[1], 'rt').readlines()
+display_next_lines = False
+for line in lines:
+    line = line.replace('\n', '')
+    if line == 'heap_tree=peak':
+        display_next_lines = True
+    elif display_next_lines:
+        if line == '#-----------':
+            break
+        print(line)


### PR DESCRIPTION
Extract from https://travis-ci.org/rouault/openjpeg/jobs/229438863 output :
```
Most CPU consuming functions:
Flat profile:
Each sample counts as 0.01 seconds.
  %   cumulative   self              self     total           
time   seconds   seconds    calls  ms/call  ms/call  name    
 29.85      0.20     0.20 15312165     0.00     0.00  opj_mqc_decode
 23.88      0.36     0.16    30595     0.01     0.01  opj_t1_dec_clnpass_generic
 14.93      0.46     0.10     9768     0.01     0.06  opj_t1_clbl_decode_processor
 11.94      0.54     0.08    24359     0.00     0.01  opj_t1_dec_refpass_mqc_generic
  4.48      0.57     0.03        3    10.00    13.33  opj_dwt_decode_real

Memory consumption profile:
n5: 182030675 (heap allocation functions) malloc/new/new[], --alloc-fns, etc.
 n2: 81687952 0x4E70F84: opj_malloc (opj_malloc.c:195)
  n1: 79970304 0x4E6E17A: opj_tcd_code_block_dec_allocate (tcd.c:1109)
   n1: 79970304 0x4E6DE30: opj_tcd_init_tile (tcd.c:1021)
    n1: 79970304 0x4E6E005: opj_tcd_init_decode_tile (tcd.c:1052)
     n1: 79970304 0x4E4B8C2: opj_j2k_read_tile_header (j2k.c:8132)
      n1: 79970304 0x4E500A3: opj_j2k_decode_tiles (j2k.c:9797)
       n1: 79970304 0x4E49BCE: opj_j2k_exec (j2k.c:7394)
        n1: 79970304 0x4E5091E: opj_j2k_decode (j2k.c:10023)
         n1: 79970304 0x4E5B576: opj_decode (openjpeg.c:430)
          n0: 79970304 0x413890: main (opj_decompress.c:1366)
  n0: 1717648 in 15 places, all below massif's threshold (01.00%)
 n3: 42844864 0x4E70FBE: opj_calloc (opj_malloc.c:203)
  n1: 38240256 0x4E4BE51: opj_j2k_update_image_data (j2k.c:8274)
   n1: 38240256 0x4E5023A: opj_j2k_decode_tiles (j2k.c:9832)
    n1: 38240256 0x4E49BCE: opj_j2k_exec (j2k.c:7394)
     n1: 38240256 0x4E5091E: opj_j2k_decode (j2k.c:10023)
      n1: 38240256 0x4E5B576: opj_decode (openjpeg.c:430)
       n0: 38240256 0x413890: main (opj_decompress.c:1366)
  n1: 3907200 0x4E6E1B1: opj_tcd_code_block_dec_allocate (tcd.c:1116)
   n1: 3907200 0x4E6DE30: opj_tcd_init_tile (tcd.c:1021)
    n1: 3907200 0x4E6E005: opj_tcd_init_decode_tile (tcd.c:1052)
     n1: 3907200 0x4E4B8C2: opj_j2k_read_tile_header (j2k.c:8132)
      n1: 3907200 0x4E500A3: opj_j2k_decode_tiles (j2k.c:9797)
       n1: 3907200 0x4E49BCE: opj_j2k_exec (j2k.c:7394)
        n1: 3907200 0x4E5091E: opj_j2k_decode (j2k.c:10023)
         n1: 3907200 0x4E5B576: opj_decode (openjpeg.c:430)
          n0: 3907200 0x413890: main (opj_decompress.c:1366)
  n0: 697408 in 34 places, all below massif's threshold (01.00%)
 n1: 38247412 0x4E70E50: opj_aligned_alloc_n (opj_malloc.c:61)
  n2: 38247412 0x4E70FDD: opj_aligned_malloc (opj_malloc.c:208)
   n1: 38240256 0x4E6C77E: opj_alloc_tile_component_data (tcd.c:624)
    n1: 38240256 0x4E6CDE6: opj_tcd_init_tile (tcd.c:757)
     n1: 38240256 0x4E6E005: opj_tcd_init_decode_tile (tcd.c:1052)
      n1: 38240256 0x4E4B8C2: opj_j2k_read_tile_header (j2k.c:8132)
       n1: 38240256 0x4E500A3: opj_j2k_decode_tiles (j2k.c:9797)
        n1: 38240256 0x4E49BCE: opj_j2k_exec (j2k.c:7394)
         n1: 38240256 0x4E5091E: opj_j2k_decode (j2k.c:10023)
          n1: 38240256 0x4E5B576: opj_decode (openjpeg.c:430)
           n0: 38240256 0x413890: main (opj_decompress.c:1366)
   n0: 7156 in 4 places, all below massif's threshold (01.00%)
 n2: 19249879 0x4E71051: opj_realloc (opj_malloc.c:234)
  n1: 19120128 0x4E500E8: opj_j2k_decode_tiles (j2k.c:9815)
   n1: 19120128 0x4E49BCE: opj_j2k_exec (j2k.c:7394)
    n1: 19120128 0x4E5091E: opj_j2k_decode (j2k.c:10023)
     n1: 19120128 0x4E5B576: opj_decode (openjpeg.c:430)
      n0: 19120128 0x413890: main (opj_decompress.c:1366)
  n0: 129751 in 2 places, all below massif's threshold (01.00%)
 n0: 568 in 1 place, below massif's threshold (01.00%)
```