### PR TITLE
Enable AVX2 at runtime on Travis-CI and AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,11 @@ matrix:
 
 # Test compilation with AVX2
     - os: linux
+      # "sudo: yes" and "dist: trusty" give us a worker with the AVX2 instruction set
+      sudo: yes
+      dist: trusty
       compiler: clang-3.8
-      # skip tests since Travis doesn't have AVX2 compatible machines
-      env: OPJ_CI_CC=clang-3.8 OPJ_CI_CXX=clang-3.8 OPJ_CI_INSTRUCTION_SETS="-mavx2" OPJ_CI_BUILD_CONFIGURATION=Release OPJ_CI_SKIP_TESTS=1
+      env: OPJ_CI_CC=clang-3.8 OPJ_CI_CXX=clang-3.8 OPJ_CI_INSTRUCTION_SETS="-mavx2" OPJ_CI_BUILD_CONFIGURATION=Release
       addons:
         apt:
           sources:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,9 @@ skip_tags: false
 clone_depth: 50
 environment:
   matrix:
+  - OPJ_CI_ARCH: x64
+    OPJ_CI_VSCOMNTOOLS: $(VS140COMNTOOLS)
+    OPJ_CI_INSTRUCTION_SETS: "/arch:AVX2"
   - OPJ_CI_ARCH: x86
     OPJ_CI_VSCOMNTOOLS: $(VS140COMNTOOLS)
     OPJ_CI_INCLUDE_IF_DEPLOY: 1

--- a/tools/travis-ci/detect-avx2.c
+++ b/tools/travis-ci/detect-avx2.c
@@ -1,0 +1,152 @@
+/*
+ * The copyright in this software is being made available under the 2-clauses
+ * BSD License, included below. This software may be subject to other third
+ * party and contributor rights, including patent rights, and no such rights
+ * are granted under this license.
+ *
+ * Copyright (c) 2017, IntoPIX SA <support@intopix.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS `AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define CPUID_SSSE3_ECX_BIT     9
+#define CPUID_OSXSAVE_ECX_BIT   27
+#define CPUID_AVX_ECX_BIT       28
+
+#define CPUID_AVX2_EBX_BIT      5
+
+#define CPUID_SSE_EDX_BIT       25
+
+#define BIT_XMM_STATE           (1 << 1)
+#define BIT_YMM_STATE           (2 << 1)
+
+#define REG_EAX                 0
+#define REG_EBX                 1
+#define REG_ECX                 2
+#define REG_EDX                 3
+
+#if defined(__GNUC__) && (defined(__i386__) ||defined(__x86_64))
+
+#include <cpuid.h>
+
+#define CPL_CPUID(level, subfunction, array) __cpuid_count(level, subfunction, array[0], array[1], array[2], array[3])
+
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+
+#include <intrin.h>
+
+#define CPL_CPUID(level, subfunction, array) __cpuidex(array, level, subfunction)
+
+#else
+
+#error "not supported"
+
+#endif
+
+#if defined(__GNUC__) && (defined(__i386__) ||defined(__x86_64))
+
+int CPLHaveRuntimeAVX()
+{
+    int cpuinfo[4] = { 0, 0, 0, 0 };
+    unsigned int nXCRLow;
+    unsigned int nXCRHigh;
+
+    CPL_CPUID(1, 0, cpuinfo);
+
+    // Check OSXSAVE feature.
+    if ((cpuinfo[REG_ECX] & (1 << CPUID_OSXSAVE_ECX_BIT)) == 0) {
+        return 0;
+    }
+
+    // Check AVX feature.
+    if ((cpuinfo[REG_ECX] & (1 << CPUID_AVX_ECX_BIT)) == 0) {
+        return 0;
+    }
+
+    // Issue XGETBV and check the XMM and YMM state bit.
+
+    __asm__("xgetbv" : "=a"(nXCRLow), "=d"(nXCRHigh) : "c"(0));
+    if ((nXCRLow & (BIT_XMM_STATE | BIT_YMM_STATE)) !=
+            (BIT_XMM_STATE | BIT_YMM_STATE)) {
+        return 0;
+    }
+
+    return 1;
+}
+
+#elif defined(_MSC_FULL_VER) && (_MSC_FULL_VER >= 160040219) && (defined(_M_IX86) || defined(_M_X64))
+// _xgetbv available only in Visual Studio 2010 SP1 or later
+
+int CPLHaveRuntimeAVX()
+{
+    int cpuinfo[4] = { 0, 0, 0, 0 };
+    unsigned __int64 xcrFeatureMask;
+
+    CPL_CPUID(1, 0, cpuinfo);
+
+    // Check OSXSAVE feature.
+    if ((cpuinfo[REG_ECX] & (1 << CPUID_OSXSAVE_ECX_BIT)) == 0) {
+        return 0;
+    }
+
+    // Check AVX feature.
+    if ((cpuinfo[REG_ECX] & (1 << CPUID_AVX_ECX_BIT)) == 0) {
+        return 0;
+    }
+
+    // Issue XGETBV and check the XMM and YMM state bit.
+    xcrFeatureMask = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+    if ((xcrFeatureMask & (BIT_XMM_STATE | BIT_YMM_STATE)) !=
+            (BIT_XMM_STATE | BIT_YMM_STATE)) {
+        return 0;
+    }
+
+    return 1;
+}
+
+#endif
+
+int CPLHaveRuntimeAVX2()
+{
+    int cpuinfo[4] = { 0, 0, 0, 0 };
+    if (!CPLHaveRuntimeAVX()) {
+        return 0;
+    }
+
+    CPL_CPUID(7, 0, cpuinfo);
+
+    // Check AVX2 feature.
+    if ((cpuinfo[REG_EBX] & (1 << CPUID_AVX2_EBX_BIT)) == 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+int main()
+{
+    if (CPLHaveRuntimeAVX2()) {
+        return 0;
+    }
+    return 1;
+}

--- a/tools/travis-ci/knownfailures-Ubuntu14.04-clang3.8.0-x86_64-Release-3rdP.txt
+++ b/tools/travis-ci/knownfailures-Ubuntu14.04-clang3.8.0-x86_64-Release-3rdP.txt
@@ -1,0 +1,8 @@
+NR-ENC-X_4_2K_24_185_CBR_WB_000.tif-15-compare_dec-ref-out2base
+NR-ENC-X_5_2K_24_235_CBR_STEM24_000.tif-16-compare_dec-ref-out2base
+NR-ENC-X_6_2K_24_FULL_CBR_CIRCLE_000.tif-17-compare_dec-ref-out2base
+NR-ENC-X_4_2K_24_185_CBR_WB_000.tif-18-compare_dec-ref-out2base
+NR-ENC-X_5_2K_24_235_CBR_STEM24_000.tif-19-compare_dec-ref-out2base
+NR-ENC-X_6_2K_24_FULL_CBR_CIRCLE_000.tif-20-compare_dec-ref-out2base
+NR-ENC-ElephantDream_4K.tif-21-compare_dec-ref-out2base
+NR-ENC-issue141.rawl-23-compare_dec-ref-out2base

--- a/tools/travis-ci/run.sh
+++ b/tools/travis-ci/run.sh
@@ -142,6 +142,15 @@ elif [ "${TRAVIS_OS_NAME}" == "windows" ]; then
 			OPJ_CC_VERSION=vs????
 		fi
 	fi
+	if [ "${OPJ_CI_INSTRUCTION_SETS-:}" == "/arch:AVX2" ]; then
+		cl $PWD/tools/travis-ci/detect-avx2.c
+		if ./detect-avx2.exe; then
+			echo "AVX2 available on CPU"
+		else
+			echo "AVX2 not available on CPU. Disabling tests"
+			export OPJ_CI_SKIP_TESTS=1
+		fi
+	fi
 else
 	echo "OS not supported: ${TRAVIS_OS_NAME}"; exit 1
 fi

--- a/tools/travis-ci/run.sh
+++ b/tools/travis-ci/run.sh
@@ -111,6 +111,17 @@ elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	else
 		echo "Compiler not supported: ${CC}"; exit 1
 	fi
+	if [ "${OPJ_CI_INSTRUCTION_SETS-:}" == "-mavx2" ]; then
+		AVX2_AVAIL=1
+		cat /proc/cpuinfo | grep avx2 >/dev/null || AVX2_AVAIL=0
+		if [[ "${AVX2_AVAIL}" == "1" ]]; then
+			echo "AVX2 available on CPU"
+		else
+			echo "AVX2 not available on CPU. Disabling tests"
+			cat /proc/cpuinfo  | grep flags | head -n 1
+			export OPJ_CI_SKIP_TESTS=1
+		fi
+        fi
 elif [ "${TRAVIS_OS_NAME}" == "windows" ]; then
 	OPJ_OS_NAME=windows
 	if which cl > /dev/null; then


### PR DESCRIPTION
* Add a /arch:AVX2 config for AppVeyor
* It turns out that some workers used by Travis-CI and AppVeyor have AVX2 compatible CPUs, so when this is the case, run the tests.