### PR TITLE
Subtile decoding: only apply IDWT on areas that participate to the window of interest

### DIFF
--- a/src/lib/openjp2/bench_dwt.c
+++ b/src/lib/openjp2/bench_dwt.c
@@ -133,7 +133,12 @@ OPJ_FLOAT64 opj_clock(void)
 int main(int argc, char** argv)
 {
     int num_threads = 0;
+    opj_tcd_t tcd;
+    opj_tcd_image_t tcd_image;
+    opj_tcd_tile_t tcd_tile;
     opj_tcd_tilecomp_t tilec;
+    opj_image_t image;
+    opj_image_comp_t image_comp;
     opj_thread_pool_t* tp;
     OPJ_INT32 i, j, k;
     OPJ_BOOL display = OPJ_FALSE;
@@ -191,8 +196,32 @@ int main(int argc, char** argv)
         }
     }
 
+    memset(&tcd, 0, sizeof(tcd));
+    tcd.thread_pool = tp;
+    tcd.decoded_x0 = (OPJ_UINT32)tilec.x0;
+    tcd.decoded_y0 = (OPJ_UINT32)tilec.y0;
+    tcd.decoded_x1 = (OPJ_UINT32)tilec.x1;
+    tcd.decoded_y1 = (OPJ_UINT32)tilec.y1;
+    tcd.tcd_image = &tcd_image;
+    memset(&tcd_image, 0, sizeof(tcd_image));
+    tcd_image.tiles = &tcd_tile;
+    memset(&tcd_tile, 0, sizeof(tcd_tile));
+    tcd_tile.x0 = tilec.x0;
+    tcd_tile.y0 = tilec.y0;
+    tcd_tile.x1 = tilec.x1;
+    tcd_tile.y1 = tilec.y1;
+    tcd_tile.numcomps = 1;
+    tcd_tile.comps = &tilec;
+    tcd.image = &image;
+    memset(&image, 0, sizeof(image));
+    image.numcomps = 1;
+    image.comps = &image_comp;
+    memset(&image_comp, 0, sizeof(image_comp));
+    image_comp.dx = 1;
+    image_comp.dy = 1;
+
     start = opj_clock();
-    opj_dwt_decode(tp, &tilec, tilec.numresolutions);
+    opj_dwt_decode(&tcd, &tilec, tilec.numresolutions);
     stop = opj_clock();
     printf("time for dwt_decode: %.03f s\n", stop - start);
 

--- a/src/lib/openjp2/dwt.c
+++ b/src/lib/openjp2/dwt.c
@@ -82,9 +82,9 @@
 
 typedef struct dwt_local {
     OPJ_INT32* mem;
-    OPJ_INT32 dn;
-    OPJ_INT32 sn;
-    OPJ_INT32 cas;
+    OPJ_INT32 dn;   /* number of elements in high pass band */
+    OPJ_INT32 sn;   /* number of elements in low pass band */
+    OPJ_INT32 cas;  /* 0 = start on even coord, 1 = start on odd coord */
 } opj_dwt_t;
 
 typedef union {
@@ -93,9 +93,13 @@ typedef union {
 
 typedef struct v4dwt_local {
     opj_v4_t*   wavelet ;
-    OPJ_INT32       dn ;
-    OPJ_INT32       sn ;
-    OPJ_INT32       cas ;
+    OPJ_INT32       dn ;  /* number of elements in high pass band */
+    OPJ_INT32       sn ;  /* number of elements in low pass band */
+    OPJ_INT32       cas ; /* 0 = start on even coord, 1 = start on odd coord */
+    OPJ_UINT32      win_l_x0; /* start coord in low pass band */
+    OPJ_UINT32      win_l_x1; /* end coord in low pass band */
+    OPJ_UINT32      win_h_x0; /* start coord in high pass band */
+    OPJ_UINT32      win_h_x1; /* end coord in high pass band */
 } opj_v4dwt_t ;
 
 static const OPJ_FLOAT32 opj_dwt_alpha =  1.586134342f; /*  12994 */
@@ -162,25 +166,38 @@ static OPJ_UINT32 opj_dwt_max_resolution(opj_tcd_resolution_t* OPJ_RESTRICT r,
 /* </summary>                            */
 static void opj_v4dwt_decode(opj_v4dwt_t* OPJ_RESTRICT dwt);
 
-static void opj_v4dwt_interleave_h(opj_v4dwt_t* OPJ_RESTRICT w,
-                                   OPJ_FLOAT32* OPJ_RESTRICT a, OPJ_INT32 x, OPJ_INT32 size);
+static void opj_v4dwt_interleave_h(opj_v4dwt_t* OPJ_RESTRICT dwt,
+                                   OPJ_FLOAT32* OPJ_RESTRICT a,
+                                   OPJ_UINT32 width,
+                                   OPJ_UINT32 remaining_height);
 
-static void opj_v4dwt_interleave_v(opj_v4dwt_t* OPJ_RESTRICT v,
-                                   OPJ_FLOAT32* OPJ_RESTRICT a, OPJ_INT32 x, OPJ_INT32 nb_elts_read);
+static void opj_v4dwt_interleave_v(opj_v4dwt_t* OPJ_RESTRICT dwt,
+                                   OPJ_FLOAT32* OPJ_RESTRICT a,
+                                   OPJ_UINT32 width,
+                                   OPJ_UINT32 nb_elts_read);
 
 #ifdef __SSE__
-static void opj_v4dwt_decode_step1_sse(opj_v4_t* w, OPJ_INT32 count,
+static void opj_v4dwt_decode_step1_sse(opj_v4_t* w,
+                                       OPJ_UINT32 start,
+                                       OPJ_UINT32 end,
                                        const __m128 c);
 
-static void opj_v4dwt_decode_step2_sse(opj_v4_t* l, opj_v4_t* w, OPJ_INT32 k,
-                                       OPJ_INT32 m, __m128 c);
+static void opj_v4dwt_decode_step2_sse(opj_v4_t* l, opj_v4_t* w,
+                                       OPJ_UINT32 start,
+                                       OPJ_UINT32 end,
+                                       OPJ_UINT32 m, __m128 c);
 
 #else
-static void opj_v4dwt_decode_step1(opj_v4_t* w, OPJ_INT32 count,
+static void opj_v4dwt_decode_step1(opj_v4_t* w,
+                                   OPJ_UINT32 start,
+                                   OPJ_UINT32 end,
                                    const OPJ_FLOAT32 c);
 
-static void opj_v4dwt_decode_step2(opj_v4_t* l, opj_v4_t* w, OPJ_INT32 k,
-                                   OPJ_INT32 m, OPJ_FLOAT32 c);
+static void opj_v4dwt_decode_step2(opj_v4_t* l, opj_v4_t* w,
+                                   OPJ_UINT32 start,
+                                   OPJ_UINT32 end,
+                                   OPJ_UINT32 m,
+                                   OPJ_FLOAT32 c);
 
 #endif
 
@@ -1839,136 +1856,143 @@ static OPJ_BOOL opj_dwt_decode_partial_tile(opj_tcd_t *tcd,
     return OPJ_TRUE;
 }
 
-static void opj_v4dwt_interleave_h(opj_v4dwt_t* OPJ_RESTRICT w,
-                                   OPJ_FLOAT32* OPJ_RESTRICT a, OPJ_INT32 x, OPJ_INT32 size)
+static void opj_v4dwt_interleave_h(opj_v4dwt_t* OPJ_RESTRICT dwt,
+                                   OPJ_FLOAT32* OPJ_RESTRICT a,
+                                   OPJ_UINT32 width,
+                                   OPJ_UINT32 remaining_height)
 {
-    OPJ_FLOAT32* OPJ_RESTRICT bi = (OPJ_FLOAT32*)(w->wavelet + w->cas);
-    OPJ_INT32 count = w->sn;
-    OPJ_INT32 i, k;
+    OPJ_FLOAT32* OPJ_RESTRICT bi = (OPJ_FLOAT32*)(dwt->wavelet + dwt->cas);
+    OPJ_UINT32 i, k;
+    OPJ_UINT32 x0 = dwt->win_l_x0;
+    OPJ_UINT32 x1 = dwt->win_l_x1;
 
     for (k = 0; k < 2; ++k) {
-        if (count + 3 * x < size && ((size_t) a & 0x0f) == 0 &&
-                ((size_t) bi & 0x0f) == 0 && (x & 0x0f) == 0) {
+        if (remaining_height >= 4 && ((size_t) a & 0x0f) == 0 &&
+                ((size_t) bi & 0x0f) == 0 && (width & 0x0f) == 0) {
             /* Fast code path */
-            for (i = 0; i < count; ++i) {
-                OPJ_INT32 j = i;
+            for (i = x0; i < x1; ++i) {
+                OPJ_UINT32 j = i;
                 bi[i * 8    ] = a[j];
-                j += x;
+                j += width;
                 bi[i * 8 + 1] = a[j];
-                j += x;
+                j += width;
                 bi[i * 8 + 2] = a[j];
-                j += x;
+                j += width;
                 bi[i * 8 + 3] = a[j];
             }
         } else {
             /* Slow code path */
-            for (i = 0; i < count; ++i) {
-                OPJ_INT32 j = i;
+            for (i = x0; i < x1; ++i) {
+                OPJ_UINT32 j = i;
                 bi[i * 8    ] = a[j];
-                j += x;
-                if (j >= size) {
+                j += width;
+                if (remaining_height == 1) {
                     continue;
                 }
                 bi[i * 8 + 1] = a[j];
-                j += x;
-                if (j >= size) {
+                j += width;
+                if (remaining_height == 2) {
                     continue;
                 }
                 bi[i * 8 + 2] = a[j];
-                j += x;
-                if (j >= size) {
+                j += width;
+                if (remaining_height == 3) {
                     continue;
                 }
                 bi[i * 8 + 3] = a[j]; /* This one*/
             }
         }
 
-        bi = (OPJ_FLOAT32*)(w->wavelet + 1 - w->cas);
-        a += w->sn;
-        size -= w->sn;
-        count = w->dn;
+        bi = (OPJ_FLOAT32*)(dwt->wavelet + 1 - dwt->cas);
+        a += dwt->sn;
+        x0 = dwt->win_h_x0;
+        x1 = dwt->win_h_x1;
     }
 }
 
-static void opj_v4dwt_interleave_v(opj_v4dwt_t* OPJ_RESTRICT v,
-                                   OPJ_FLOAT32* OPJ_RESTRICT a, OPJ_INT32 x, OPJ_INT32 nb_elts_read)
+static void opj_v4dwt_interleave_v(opj_v4dwt_t* OPJ_RESTRICT dwt,
+                                   OPJ_FLOAT32* OPJ_RESTRICT a,
+                                   OPJ_UINT32 width,
+                                   OPJ_UINT32 nb_elts_read)
 {
-    opj_v4_t* OPJ_RESTRICT bi = v->wavelet + v->cas;
-    OPJ_INT32 i;
+    opj_v4_t* OPJ_RESTRICT bi = dwt->wavelet + dwt->cas;
+    OPJ_UINT32 i;
 
-    for (i = 0; i < v->sn; ++i) {
-        memcpy(&bi[i * 2], &a[i * x], (size_t)nb_elts_read * sizeof(OPJ_FLOAT32));
+    for (i = dwt->win_l_x0; i < dwt->win_l_x1; ++i) {
+        memcpy(&bi[i * 2], &a[i * width], (size_t)nb_elts_read * sizeof(OPJ_FLOAT32));
     }
 
-    a += v->sn * x;
-    bi = v->wavelet + 1 - v->cas;
+    a += (OPJ_UINT32)dwt->sn * width;
+    bi = dwt->wavelet + 1 - dwt->cas;
 
-    for (i = 0; i < v->dn; ++i) {
-        memcpy(&bi[i * 2], &a[i * x], (size_t)nb_elts_read * sizeof(OPJ_FLOAT32));
+    for (i = dwt->win_h_x0; i < dwt->win_h_x1; ++i) {
+        memcpy(&bi[i * 2], &a[i * width], (size_t)nb_elts_read * sizeof(OPJ_FLOAT32));
     }
 }
 
 #ifdef __SSE__
 
-static void opj_v4dwt_decode_step1_sse(opj_v4_t* w, OPJ_INT32 count,
+static void opj_v4dwt_decode_step1_sse(opj_v4_t* w,
+                                       OPJ_UINT32 start,
+                                       OPJ_UINT32 end,
                                        const __m128 c)
 {
     __m128* OPJ_RESTRICT vw = (__m128*) w;
-    OPJ_INT32 i;
+    OPJ_UINT32 i;
     /* 4x unrolled loop */
-    for (i = 0; i < count >> 2; ++i) {
-        *vw = _mm_mul_ps(*vw, c);
-        vw += 2;
-        *vw = _mm_mul_ps(*vw, c);
-        vw += 2;
-        *vw = _mm_mul_ps(*vw, c);
-        vw += 2;
-        *vw = _mm_mul_ps(*vw, c);
-        vw += 2;
+    for (i = start; i + 3 < end; i += 4) {
+        vw[2 * i] = _mm_mul_ps(vw[2 * i], c);
+        vw[2 * i + 2] = _mm_mul_ps(vw[2 * i + 2], c);
+        vw[2 * i + 4] = _mm_mul_ps(vw[2 * i + 4], c);
+        vw[2 * i + 6] = _mm_mul_ps(vw[2 * i + 6], c);
     }
-    count &= 3;
-    for (i = 0; i < count; ++i) {
-        *vw = _mm_mul_ps(*vw, c);
-        vw += 2;
+    for (; i < end; ++i) {
+        vw[2 * i] = _mm_mul_ps(vw[2 * i], c);
     }
 }
 
-void opj_v4dwt_decode_step2_sse(opj_v4_t* l, opj_v4_t* w, OPJ_INT32 k,
-                                OPJ_INT32 m, __m128 c)
+static void opj_v4dwt_decode_step2_sse(opj_v4_t* l, opj_v4_t* w,
+                                       OPJ_UINT32 start,
+                                       OPJ_UINT32 end,
+                                       OPJ_UINT32 m,
+                                       __m128 c)
 {
     __m128* OPJ_RESTRICT vl = (__m128*) l;
     __m128* OPJ_RESTRICT vw = (__m128*) w;
-    OPJ_INT32 i;
+    OPJ_UINT32 i;
+    OPJ_UINT32 imax = opj_uint_min(end, m);
     __m128 tmp1, tmp2, tmp3;
-    tmp1 = vl[0];
-    for (i = 0; i < m; ++i) {
+    if (start == 0) {
+        tmp1 = vl[0];
+    } else {
+        vw += start * 2;
+        tmp1 = vw[-3];
+    }
+    for (i = start; i < imax; ++i) {
         tmp2 = vw[-1];
         tmp3 = vw[ 0];
         vw[-1] = _mm_add_ps(tmp2, _mm_mul_ps(_mm_add_ps(tmp1, tmp3), c));
         tmp1 = tmp3;
         vw += 2;
     }
-    vl = vw - 2;
-    if (m >= k) {
-        return;
-    }
-    c = _mm_add_ps(c, c);
-    c = _mm_mul_ps(c, vl[0]);
-    for (; m < k; ++m) {
-        __m128 tmp = vw[-1];
-        vw[-1] = _mm_add_ps(tmp, c);
-        vw += 2;
+    if (m < end) {
+        assert(m + 1 == end);
+        c = _mm_add_ps(c, c);
+        c = _mm_mul_ps(c, vw[-2]);
+        vw[-1] = _mm_add_ps(vw[-1], c);
     }
 }
 
 #else
 
-static void opj_v4dwt_decode_step1(opj_v4_t* w, OPJ_INT32 count,
+static void opj_v4dwt_decode_step1(opj_v4_t* w,
+                                   OPJ_UINT32 start,
+                                   OPJ_UINT32 end,
                                    const OPJ_FLOAT32 c)
 {
     OPJ_FLOAT32* OPJ_RESTRICT fw = (OPJ_FLOAT32*) w;
-    OPJ_INT32 i;
-    for (i = 0; i < count; ++i) {
+    OPJ_UINT32 i;
+    for (i = start; i < end; ++i) {
         OPJ_FLOAT32 tmp1 = fw[i * 8    ];
         OPJ_FLOAT32 tmp2 = fw[i * 8 + 1];
         OPJ_FLOAT32 tmp3 = fw[i * 8 + 2];
@@ -1980,13 +2004,21 @@ static void opj_v4dwt_decode_step1(opj_v4_t* w, OPJ_INT32 count,
     }
 }
 
-static void opj_v4dwt_decode_step2(opj_v4_t* l, opj_v4_t* w, OPJ_INT32 k,
-                                   OPJ_INT32 m, OPJ_FLOAT32 c)
+static void opj_v4dwt_decode_step2(opj_v4_t* l, opj_v4_t* w,
+                                   OPJ_UINT32 start,
+                                   OPJ_UINT32 end,
+                                   OPJ_UINT32 m,
+                                   OPJ_FLOAT32 c)
 {
     OPJ_FLOAT32* fl = (OPJ_FLOAT32*) l;
     OPJ_FLOAT32* fw = (OPJ_FLOAT32*) w;
-    OPJ_INT32 i;
-    for (i = 0; i < m; ++i) {
+    OPJ_UINT32 i;
+    OPJ_UINT32 imax = opj_uint_min(end, m);
+    if (start > 0) {
+        fw += 8 * start;
+        fl = fw - 8;
+    }
+    for (i = start; i < imax; ++i) {
         OPJ_FLOAT32 tmp1_1 = fl[0];
         OPJ_FLOAT32 tmp1_2 = fl[1];
         OPJ_FLOAT32 tmp1_3 = fl[2];
@@ -2006,27 +2038,13 @@ static void opj_v4dwt_decode_step2(opj_v4_t* l, opj_v4_t* w, OPJ_INT32 k,
         fl = fw;
         fw += 8;
     }
-    if (m < k) {
-        OPJ_FLOAT32 c1;
-        OPJ_FLOAT32 c2;
-        OPJ_FLOAT32 c3;
-        OPJ_FLOAT32 c4;
+    if (m < end) {
+        assert(m + 1 == end);
         c += c;
-        c1 = fl[0] * c;
-        c2 = fl[1] * c;
-        c3 = fl[2] * c;
-        c4 = fl[3] * c;
-        for (; m < k; ++m) {
-            OPJ_FLOAT32 tmp1 = fw[-4];
-            OPJ_FLOAT32 tmp2 = fw[-3];
-            OPJ_FLOAT32 tmp3 = fw[-2];
-            OPJ_FLOAT32 tmp4 = fw[-1];
-            fw[-4] = tmp1 + c1;
-            fw[-3] = tmp2 + c2;
-            fw[-2] = tmp3 + c3;
-            fw[-1] = tmp4 + c4;
-            fw += 8;
-        }
+        fw[-4] = fw[-4] + fl[0] * c;
+        fw[-3] = fw[-3] + fl[1] * c;
+        fw[-2] = fw[-2] + fl[2] * c;
+        fw[-1] = fw[-1] + fl[3] * c;
     }
 }
 
@@ -2052,27 +2070,47 @@ static void opj_v4dwt_decode(opj_v4dwt_t* OPJ_RESTRICT dwt)
         b = 0;
     }
 #ifdef __SSE__
-    opj_v4dwt_decode_step1_sse(dwt->wavelet + a, dwt->sn, _mm_set1_ps(opj_K));
-    opj_v4dwt_decode_step1_sse(dwt->wavelet + b, dwt->dn, _mm_set1_ps(opj_c13318));
-    opj_v4dwt_decode_step2_sse(dwt->wavelet + b, dwt->wavelet + a + 1, dwt->sn,
-                               opj_int_min(dwt->sn, dwt->dn - a), _mm_set1_ps(opj_dwt_delta));
-    opj_v4dwt_decode_step2_sse(dwt->wavelet + a, dwt->wavelet + b + 1, dwt->dn,
-                               opj_int_min(dwt->dn, dwt->sn - b), _mm_set1_ps(opj_dwt_gamma));
-    opj_v4dwt_decode_step2_sse(dwt->wavelet + b, dwt->wavelet + a + 1, dwt->sn,
-                               opj_int_min(dwt->sn, dwt->dn - a), _mm_set1_ps(opj_dwt_beta));
-    opj_v4dwt_decode_step2_sse(dwt->wavelet + a, dwt->wavelet + b + 1, dwt->dn,
-                               opj_int_min(dwt->dn, dwt->sn - b), _mm_set1_ps(opj_dwt_alpha));
+    opj_v4dwt_decode_step1_sse(dwt->wavelet + a, dwt->win_l_x0, dwt->win_l_x1,
+                               _mm_set1_ps(opj_K));
+    opj_v4dwt_decode_step1_sse(dwt->wavelet + b, dwt->win_h_x0, dwt->win_h_x1,
+                               _mm_set1_ps(opj_c13318));
+    opj_v4dwt_decode_step2_sse(dwt->wavelet + b, dwt->wavelet + a + 1,
+                               dwt->win_l_x0, dwt->win_l_x1,
+                               (OPJ_UINT32)opj_int_min(dwt->sn, dwt->dn - a),
+                               _mm_set1_ps(opj_dwt_delta));
+    opj_v4dwt_decode_step2_sse(dwt->wavelet + a, dwt->wavelet + b + 1,
+                               dwt->win_h_x0, dwt->win_h_x1,
+                               (OPJ_UINT32)opj_int_min(dwt->dn, dwt->sn - b),
+                               _mm_set1_ps(opj_dwt_gamma));
+    opj_v4dwt_decode_step2_sse(dwt->wavelet + b, dwt->wavelet + a + 1,
+                               dwt->win_l_x0, dwt->win_l_x1,
+                               (OPJ_UINT32)opj_int_min(dwt->sn, dwt->dn - a),
+                               _mm_set1_ps(opj_dwt_beta));
+    opj_v4dwt_decode_step2_sse(dwt->wavelet + a, dwt->wavelet + b + 1,
+                               dwt->win_h_x0, dwt->win_h_x1,
+                               (OPJ_UINT32)opj_int_min(dwt->dn, dwt->sn - b),
+                               _mm_set1_ps(opj_dwt_alpha));
 #else
-    opj_v4dwt_decode_step1(dwt->wavelet + a, dwt->sn, opj_K);
-    opj_v4dwt_decode_step1(dwt->wavelet + b, dwt->dn, opj_c13318);
-    opj_v4dwt_decode_step2(dwt->wavelet + b, dwt->wavelet + a + 1, dwt->sn,
-                           opj_int_min(dwt->sn, dwt->dn - a), opj_dwt_delta);
-    opj_v4dwt_decode_step2(dwt->wavelet + a, dwt->wavelet + b + 1, dwt->dn,
-                           opj_int_min(dwt->dn, dwt->sn - b), opj_dwt_gamma);
-    opj_v4dwt_decode_step2(dwt->wavelet + b, dwt->wavelet + a + 1, dwt->sn,
-                           opj_int_min(dwt->sn, dwt->dn - a), opj_dwt_beta);
-    opj_v4dwt_decode_step2(dwt->wavelet + a, dwt->wavelet + b + 1, dwt->dn,
-                           opj_int_min(dwt->dn, dwt->sn - b), opj_dwt_alpha);
+    opj_v4dwt_decode_step1(dwt->wavelet + a, dwt->win_l_x0, dwt->win_l_x1,
+                           opj_K);
+    opj_v4dwt_decode_step1(dwt->wavelet + b, dwt->win_h_x0, dwt->win_h_x1,
+                           opj_c13318);
+    opj_v4dwt_decode_step2(dwt->wavelet + b, dwt->wavelet + a + 1,
+                           dwt->win_l_x0, dwt->win_l_x1,
+                           (OPJ_UINT32)opj_int_min(dwt->sn, dwt->dn - a),
+                           opj_dwt_delta);
+    opj_v4dwt_decode_step2(dwt->wavelet + a, dwt->wavelet + b + 1,
+                           dwt->win_h_x0, dwt->win_h_x1,
+                           (OPJ_UINT32)opj_int_min(dwt->dn, dwt->sn - b),
+                           opj_dwt_gamma);
+    opj_v4dwt_decode_step2(dwt->wavelet + b, dwt->wavelet + a + 1,
+                           dwt->win_l_x0, dwt->win_l_x1,
+                           (OPJ_UINT32)opj_int_min(dwt->sn, dwt->dn - a),
+                           opj_dwt_beta);
+    opj_v4dwt_decode_step2(dwt->wavelet + a, dwt->wavelet + b + 1,
+                           dwt->win_h_x0, dwt->win_h_x1,
+                           (OPJ_UINT32)opj_int_min(dwt->dn, dwt->sn - b),
+                           opj_dwt_alpha);
 #endif
 }
 
@@ -2080,8 +2118,9 @@ static void opj_v4dwt_decode(opj_v4dwt_t* OPJ_RESTRICT dwt)
 /* <summary>                             */
 /* Inverse 9-7 wavelet transform in 2-D. */
 /* </summary>                            */
-OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
-                             OPJ_UINT32 numres)
+static
+OPJ_BOOL opj_dwt_decode_tile_97(opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
+                                OPJ_UINT32 numres)
 {
     opj_v4dwt_t h;
     opj_v4dwt_t v;
@@ -2118,9 +2157,7 @@ OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
 
     while (--numres) {
         OPJ_FLOAT32 * OPJ_RESTRICT aj = (OPJ_FLOAT32*) tilec->data;
-        OPJ_UINT32 bufsize = (OPJ_UINT32)((tilec->x1 - tilec->x0) *
-                                          (tilec->y1 - tilec->y0));
-        OPJ_INT32 j;
+        OPJ_UINT32 j;
 
         h.sn = (OPJ_INT32)rw;
         v.sn = (OPJ_INT32)rh;
@@ -2135,49 +2172,55 @@ OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
         h.dn = (OPJ_INT32)(rw - (OPJ_UINT32)h.sn);
         h.cas = res->x0 % 2;
 
-        for (j = (OPJ_INT32)rh; j > 3; j -= 4) {
-            OPJ_INT32 k;
-            opj_v4dwt_interleave_h(&h, aj, (OPJ_INT32)w, (OPJ_INT32)bufsize);
+        h.win_l_x0 = 0;
+        h.win_l_x1 = (OPJ_UINT32)h.sn;
+        h.win_h_x0 = 0;
+        h.win_h_x1 = (OPJ_UINT32)h.dn;
+        for (j = 0; j + 3 < rh; j += 4) {
+            OPJ_UINT32 k;
+            opj_v4dwt_interleave_h(&h, aj, w, rh - j);
             opj_v4dwt_decode(&h);
 
-            for (k = (OPJ_INT32)rw; --k >= 0;) {
-                aj[k               ] = h.wavelet[k].f[0];
-                aj[k + (OPJ_INT32)w  ] = h.wavelet[k].f[1];
-                aj[k + (OPJ_INT32)w * 2] = h.wavelet[k].f[2];
-                aj[k + (OPJ_INT32)w * 3] = h.wavelet[k].f[3];
+            for (k = 0; k < rw; k++) {
+                aj[k      ] = h.wavelet[k].f[0];
+                aj[k + w  ] = h.wavelet[k].f[1];
+                aj[k + w * 2] = h.wavelet[k].f[2];
+                aj[k + w * 3] = h.wavelet[k].f[3];
             }
 
             aj += w * 4;
-            bufsize -= w * 4;
         }
 
-        if (rh & 0x03) {
-            OPJ_INT32 k;
-            j = rh & 0x03;
-            opj_v4dwt_interleave_h(&h, aj, (OPJ_INT32)w, (OPJ_INT32)bufsize);
+        if (j < rh) {
+            OPJ_UINT32 k;
+            opj_v4dwt_interleave_h(&h, aj, w, rh - j);
             opj_v4dwt_decode(&h);
-            for (k = (OPJ_INT32)rw; --k >= 0;) {
-                switch (j) {
+            for (k = 0; k < rw; k++) {
+                switch (rh - j) {
                 case 3:
-                    aj[k + (OPJ_INT32)w * 2] = h.wavelet[k].f[2];
+                    aj[k + w * 2] = h.wavelet[k].f[2];
                 /* FALLTHRU */
                 case 2:
-                    aj[k + (OPJ_INT32)w  ] = h.wavelet[k].f[1];
+                    aj[k + w  ] = h.wavelet[k].f[1];
                 /* FALLTHRU */
                 case 1:
-                    aj[k               ] = h.wavelet[k].f[0];
+                    aj[k] = h.wavelet[k].f[0];
                 }
             }
         }
 
         v.dn = (OPJ_INT32)(rh - (OPJ_UINT32)v.sn);
         v.cas = res->y0 % 2;
+        v.win_l_x0 = 0;
+        v.win_l_x1 = (OPJ_UINT32)v.sn;
+        v.win_h_x0 = 0;
+        v.win_h_x1 = (OPJ_UINT32)v.dn;
 
         aj = (OPJ_FLOAT32*) tilec->data;
-        for (j = (OPJ_INT32)rw; j > 3; j -= 4) {
+        for (j = rw; j > 3; j -= 4) {
             OPJ_UINT32 k;
 
-            opj_v4dwt_interleave_v(&v, aj, (OPJ_INT32)w, 4);
+            opj_v4dwt_interleave_v(&v, aj, w, 4);
             opj_v4dwt_decode(&v);
 
             for (k = 0; k < rh; ++k) {
@@ -2191,7 +2234,7 @@ OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
 
             j = rw & 0x03;
 
-            opj_v4dwt_interleave_v(&v, aj, (OPJ_INT32)w, j);
+            opj_v4dwt_interleave_v(&v, aj, w, j);
             opj_v4dwt_decode(&v);
 
             for (k = 0; k < rh; ++k) {
@@ -2202,4 +2245,221 @@ OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
 
     opj_aligned_free(h.wavelet);
     return OPJ_TRUE;
+}
+
+static
+OPJ_BOOL opj_dwt_decode_partial_97(opj_tcd_t *tcd,
+                                   opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
+                                   OPJ_UINT32 numres)
+{
+    opj_v4dwt_t h;
+    opj_v4dwt_t v;
+    OPJ_UINT32 resno;
+    const OPJ_UINT32 filter_width = 4U;
+
+    opj_tcd_resolution_t* tr = tilec->resolutions;
+
+    OPJ_UINT32 rw = (OPJ_UINT32)(tr->x1 -
+                                 tr->x0);    /* width of the resolution level computed */
+    OPJ_UINT32 rh = (OPJ_UINT32)(tr->y1 -
+                                 tr->y0);    /* height of the resolution level computed */
+
+    OPJ_UINT32 w = (OPJ_UINT32)(tilec->x1 - tilec->x0);
+
+    size_t l_data_size;
+
+    opj_image_comp_t* image_comp = &(tcd->image->comps[tilec->compno]);
+    /* Compute the intersection of the area of interest, expressed in tile coordinates */
+    /* with the tile coordinates */
+    OPJ_UINT32 win_tcx0 = opj_uint_max(
+                              (OPJ_UINT32)tilec->x0,
+                              opj_uint_ceildiv(tcd->decoded_x0, image_comp->dx));
+    OPJ_UINT32 win_tcy0 = opj_uint_max(
+                              (OPJ_UINT32)tilec->y0,
+                              opj_uint_ceildiv(tcd->decoded_y0, image_comp->dy));
+    OPJ_UINT32 win_tcx1 = opj_uint_min(
+                              (OPJ_UINT32)tilec->x1,
+                              opj_uint_ceildiv(tcd->decoded_x1, image_comp->dx));
+    OPJ_UINT32 win_tcy1 = opj_uint_min(
+                              (OPJ_UINT32)tilec->y1,
+                              opj_uint_ceildiv(tcd->decoded_y1, image_comp->dy));
+
+    l_data_size = opj_dwt_max_resolution(tr, numres);
+    /* overflow check */
+    if (l_data_size > (SIZE_MAX - 5U)) {
+        /* FIXME event manager error callback */
+        return OPJ_FALSE;
+    }
+    l_data_size += 5U;
+    /* overflow check */
+    if (l_data_size > (SIZE_MAX / sizeof(opj_v4_t))) {
+        /* FIXME event manager error callback */
+        return OPJ_FALSE;
+    }
+    h.wavelet = (opj_v4_t*) opj_aligned_malloc(l_data_size * sizeof(opj_v4_t));
+    if (!h.wavelet) {
+        /* FIXME event manager error callback */
+        return OPJ_FALSE;
+    }
+    v.wavelet = h.wavelet;
+
+    for (resno = 1; --numres; resno++) {
+        OPJ_FLOAT32 * OPJ_RESTRICT aj = (OPJ_FLOAT32*) tilec->data;
+        OPJ_UINT32 j;
+        /* Window of interest subband-based coordinates */
+        OPJ_UINT32 win_ll_x0, win_ll_y0, win_ll_x1, win_ll_y1;
+        OPJ_UINT32 win_hl_x0, win_hl_x1;
+        OPJ_UINT32 win_lh_y0, win_lh_y1;
+        /* Window of interest tile-resolution-based coordinates */
+        OPJ_UINT32 win_tr_x0, win_tr_x1, win_tr_y0, win_tr_y1;
+        /* Tile-resolution subband-based coordinates */
+        OPJ_UINT32 tr_ll_x0, tr_ll_y0, tr_hl_x0, tr_lh_y0;
+
+        ++tr;
+
+        h.sn = (OPJ_INT32)rw;
+        v.sn = (OPJ_INT32)rh;
+
+        rw = (OPJ_UINT32)(tr->x1 - tr->x0);
+        rh = (OPJ_UINT32)(tr->y1 - tr->y0);
+
+        h.dn = (OPJ_INT32)(rw - (OPJ_UINT32)h.sn);
+        h.cas = tr->x0 % 2;
+
+        v.dn = (OPJ_INT32)(rh - (OPJ_UINT32)v.sn);
+        v.cas = tr->y0 % 2;
+
+        /* Get the subband coordinates for the window of interest */
+        /* LL band */
+        opj_dwt_get_band_coordinates(tilec, resno, 0,
+                                     win_tcx0, win_tcy0, win_tcx1, win_tcy1,
+                                     &win_ll_x0, &win_ll_y0,
+                                     &win_ll_x1, &win_ll_y1);
+
+        /* HL band */
+        opj_dwt_get_band_coordinates(tilec, resno, 1,
+                                     win_tcx0, win_tcy0, win_tcx1, win_tcy1,
+                                     &win_hl_x0, NULL, &win_hl_x1, NULL);
+
+        /* LH band */
+        opj_dwt_get_band_coordinates(tilec, resno, 2,
+                                     win_tcx0, win_tcy0, win_tcx1, win_tcy1,
+                                     NULL, &win_lh_y0, NULL, &win_lh_y1);
+
+        /* Beware: band index for non-LL0 resolution are 0=HL, 1=LH and 2=HH */
+        tr_ll_x0 = (OPJ_UINT32)tr->bands[1].x0;
+        tr_ll_y0 = (OPJ_UINT32)tr->bands[0].y0;
+        tr_hl_x0 = (OPJ_UINT32)tr->bands[0].x0;
+        tr_lh_y0 = (OPJ_UINT32)tr->bands[1].y0;
+
+        /* Substract the origin of the bands for this tile, to the subwindow */
+        /* of interest band coordinates, so as to get them relative to the */
+        /* tile */
+        win_ll_x0 = opj_uint_subs(win_ll_x0, tr_ll_x0);
+        win_ll_y0 = opj_uint_subs(win_ll_y0, tr_ll_y0);
+        win_ll_x1 = opj_uint_subs(win_ll_x1, tr_ll_x0);
+        win_ll_y1 = opj_uint_subs(win_ll_y1, tr_ll_y0);
+        win_hl_x0 = opj_uint_subs(win_hl_x0, tr_hl_x0);
+        win_hl_x1 = opj_uint_subs(win_hl_x1, tr_hl_x0);
+        win_lh_y0 = opj_uint_subs(win_lh_y0, tr_lh_y0);
+        win_lh_y1 = opj_uint_subs(win_lh_y1, tr_lh_y0);
+
+        opj_dwt_segment_grow(filter_width, (OPJ_UINT32)h.sn, &win_ll_x0, &win_ll_x1);
+        opj_dwt_segment_grow(filter_width, (OPJ_UINT32)h.dn, &win_hl_x0, &win_hl_x1);
+
+        opj_dwt_segment_grow(filter_width, (OPJ_UINT32)v.sn, &win_ll_y0, &win_ll_y1);
+        opj_dwt_segment_grow(filter_width, (OPJ_UINT32)v.dn, &win_lh_y0, &win_lh_y1);
+
+        /* Compute the tile-resolution-based coordinates for the window of interest */
+        if (h.cas == 0) {
+            win_tr_x0 = opj_uint_min(2 * win_ll_x0, 2 * win_hl_x0 + 1);
+            win_tr_x1 = opj_uint_min(opj_uint_max(2 * win_ll_x1, 2 * win_hl_x1 + 1), rw);
+        } else {
+            win_tr_x0 = opj_uint_min(2 * win_hl_x0, 2 * win_ll_x0 + 1);
+            win_tr_x1 = opj_uint_min(opj_uint_max(2 * win_hl_x1, 2 * win_ll_x1 + 1), rw);
+        }
+
+        if (v.cas == 0) {
+            win_tr_y0 = opj_uint_min(2 * win_ll_y0, 2 * win_lh_y0 + 1);
+            win_tr_y1 = opj_uint_min(opj_uint_max(2 * win_ll_y1, 2 * win_lh_y1 + 1), rh);
+        } else {
+            win_tr_y0 = opj_uint_min(2 * win_lh_y0, 2 * win_ll_y0 + 1);
+            win_tr_y1 = opj_uint_min(opj_uint_max(2 * win_lh_y1, 2 * win_ll_y1 + 1), rh);
+        }
+
+        h.win_l_x0 = win_ll_x0;
+        h.win_l_x1 = win_ll_x1;
+        h.win_h_x0 = win_hl_x0;
+        h.win_h_x1 = win_hl_x1;
+        for (j = 0; j + 3 < rh; j += 4, aj += w * 4) {
+            if ((j + 3 >= win_ll_y0 && j < win_ll_y1) ||
+                    (j + 3 >= win_lh_y0 + (OPJ_UINT32)v.sn &&
+                     j < win_lh_y1 + (OPJ_UINT32)v.sn)) {
+                OPJ_UINT32 k;
+                opj_v4dwt_interleave_h(&h, aj, w, rh - j);
+                opj_v4dwt_decode(&h);
+
+                for (k = 0; k < rw; k++) {
+                    aj[k        ] = h.wavelet[k].f[0];
+                    aj[k + w    ] = h.wavelet[k].f[1];
+                    aj[k + w * 2] = h.wavelet[k].f[2];
+                    aj[k + w * 3] = h.wavelet[k].f[3];
+                }
+            }
+        }
+
+        if (j < rh &&
+                ((j + 3 >= win_ll_y0 && j < win_ll_y1) ||
+                 (j + 3 >= win_lh_y0 + (OPJ_UINT32)v.sn &&
+                  j < win_lh_y1 + (OPJ_UINT32)v.sn))) {
+            OPJ_UINT32 k;
+            opj_v4dwt_interleave_h(&h, aj, w, rh - j);
+            opj_v4dwt_decode(&h);
+            for (k = 0; k < rw; k++) {
+                switch (rh - j) {
+                case 3:
+                    aj[k + w * 2] = h.wavelet[k].f[2];
+                /* FALLTHRU */
+                case 2:
+                    aj[k + w    ] = h.wavelet[k].f[1];
+                /* FALLTHRU */
+                case 1:
+                    aj[k        ] = h.wavelet[k].f[0];
+                }
+            }
+        }
+
+        v.win_l_x0 = win_ll_y0;
+        v.win_l_x1 = win_ll_y1;
+        v.win_h_x0 = win_lh_y0;
+        v.win_h_x1 = win_lh_y1;
+        aj = (OPJ_FLOAT32*) tilec->data;
+        aj += win_tr_x0;
+        for (j = win_tr_x0; j < win_tr_x1; j += 4, aj += 4) {
+            OPJ_UINT32 nb_elts = opj_uint_min(4U, win_tr_x1 - j);
+            OPJ_UINT32 k;
+
+            opj_v4dwt_interleave_v(&v, aj, w, nb_elts);
+            opj_v4dwt_decode(&v);
+
+            for (k = win_tr_y0; k < win_tr_y1; ++k) {
+                memcpy(&aj[k * w], &v.wavelet[k], nb_elts * sizeof(OPJ_FLOAT32));
+            }
+        }
+    }
+
+    opj_aligned_free(h.wavelet);
+    return OPJ_TRUE;
+}
+
+
+OPJ_BOOL opj_dwt_decode_real(opj_tcd_t *p_tcd,
+                             opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
+                             OPJ_UINT32 numres)
+{
+    if (opj_dwt_is_whole_tile_decoding(p_tcd, tilec)) {
+        return opj_dwt_decode_tile_97(tilec, numres);
+    } else {
+        return opj_dwt_decode_partial_97(p_tcd, tilec, numres);
+    }
 }

--- a/src/lib/openjp2/dwt.c
+++ b/src/lib/openjp2/dwt.c
@@ -1676,6 +1676,8 @@ static OPJ_BOOL opj_dwt_decode_partial_tile(opj_tcd_t *tcd,
     opj_dwt_t h;
     opj_dwt_t v;
     OPJ_UINT32 resno;
+    /* This value matches the maximum left/right extension given in tables */
+    /* F.2 and F.3 of the standard. */
     const OPJ_UINT32 filter_width = 2U;
 
     opj_tcd_resolution_t* tr = tilec->resolutions;
@@ -2255,6 +2257,9 @@ OPJ_BOOL opj_dwt_decode_partial_97(opj_tcd_t *tcd,
     opj_v4dwt_t h;
     opj_v4dwt_t v;
     OPJ_UINT32 resno;
+    /* This value matches the maximum left/right extension given in tables */
+    /* F.2 and F.3 of the standard. Note: in opj_tcd_is_subband_area_of_interest() */
+    /* we currently use 3. */
     const OPJ_UINT32 filter_width = 4U;
 
     opj_tcd_resolution_t* tr = tilec->resolutions;

--- a/src/lib/openjp2/dwt.h
+++ b/src/lib/openjp2/dwt.h
@@ -93,10 +93,12 @@ OPJ_BOOL opj_dwt_encode_real(opj_tcd_tilecomp_t * tilec);
 /**
 Inverse 9-7 wavelet transform in 2-D.
 Apply an irreversible inverse DWT transform to a component of an image.
+@param tcd TCD handle
 @param tilec Tile component information (current tile)
 @param numres Number of resolution levels to decode
 */
-OPJ_BOOL opj_dwt_decode_real(opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
+OPJ_BOOL opj_dwt_decode_real(opj_tcd_t *p_tcd,
+                             opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
                              OPJ_UINT32 numres);
 
 /**

--- a/src/lib/openjp2/dwt.h
+++ b/src/lib/openjp2/dwt.h
@@ -63,11 +63,12 @@ OPJ_BOOL opj_dwt_encode(opj_tcd_tilecomp_t * tilec);
 /**
 Inverse 5-3 wavelet transform in 2-D.
 Apply a reversible inverse DWT transform to a component of an image.
-@param tp Thread pool
+@param tcd TCD handle
 @param tilec Tile component information (current tile)
 @param numres Number of resolution levels to decode
 */
-OPJ_BOOL opj_dwt_decode(opj_thread_pool_t* tp, opj_tcd_tilecomp_t* tilec,
+OPJ_BOOL opj_dwt_decode(opj_tcd_t *p_tcd,
+                        opj_tcd_tilecomp_t* tilec,
                         OPJ_UINT32 numres);
 
 /**

--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -5171,6 +5171,10 @@ static OPJ_BOOL opj_j2k_update_rates(opj_j2k_t *p_j2k,
     /* number of packets and number of code blocks in packets */
     l_tile_size = (OPJ_UINT32)(l_tile_size * 1.4 / 8);
 
+    /* Arbitrary amount to make the following work: */
+    /* bin/test_tile_encoder 1 256 256 17 16 8 0 reversible_no_precinct.j2k 4 4 3 0 0 1 */
+    l_tile_size += 500;
+
     l_tile_size += opj_j2k_get_specific_header_sizes(p_j2k);
 
     p_j2k->m_specific_param.m_encoder.m_encoded_tile_size = l_tile_size;

--- a/src/lib/openjp2/opj_intmath.h
+++ b/src/lib/openjp2/opj_intmath.h
@@ -96,6 +96,15 @@ static INLINE OPJ_UINT32 opj_uint_adds(OPJ_UINT32 a, OPJ_UINT32 b)
 }
 
 /**
+ Get the saturated difference of two unsigned integers
+ @return Returns saturated sum of a-b
+ */
+static INLINE OPJ_UINT32 opj_uint_subs(OPJ_UINT32 a, OPJ_UINT32 b)
+{
+    return (a >= b) ? a - b : 0;
+}
+
+/**
 Clamp an integer inside an interval
 @return
 <ul>

--- a/src/lib/openjp2/t1.c
+++ b/src/lib/openjp2/t1.c
@@ -1751,7 +1751,7 @@ static void opj_t1_clbl_decode_processor(void* user_data, opj_tls_t* tls)
 }
 
 
-void opj_t1_decode_cblks(opj_thread_pool_t* tp,
+void opj_t1_decode_cblks(opj_tcd_t* tcd,
                          volatile OPJ_BOOL* pret,
                          opj_tcd_tilecomp_t* tilec,
                          opj_tccp_t* tccp,
@@ -1760,6 +1760,7 @@ void opj_t1_decode_cblks(opj_thread_pool_t* tp,
                          OPJ_BOOL check_pterm
                         )
 {
+    opj_thread_pool_t* tp = tcd->thread_pool;
     OPJ_UINT32 resno, bandno, precno, cblkno;
 
     for (resno = 0; resno < tilec->minimum_num_resolutions; ++resno) {
@@ -1774,6 +1775,17 @@ void opj_t1_decode_cblks(opj_thread_pool_t* tp,
                 for (cblkno = 0; cblkno < precinct->cw * precinct->ch; ++cblkno) {
                     opj_tcd_cblk_dec_t* cblk = &precinct->cblks.dec[cblkno];
                     opj_t1_cblk_decode_processing_job_t* job;
+
+                    if (!opj_tcd_is_subband_area_of_interest(tcd,
+                            tilec->compno,
+                            resno,
+                            band->bandno,
+                            (OPJ_UINT32)cblk->x0,
+                            (OPJ_UINT32)cblk->y0,
+                            (OPJ_UINT32)cblk->x1,
+                            (OPJ_UINT32)cblk->y1)) {
+                        continue;
+                    }
 
                     job = (opj_t1_cblk_decode_processing_job_t*) opj_calloc(1,
                             sizeof(opj_t1_cblk_decode_processing_job_t));

--- a/src/lib/openjp2/t1.c
+++ b/src/lib/openjp2/t1.c
@@ -1802,7 +1802,7 @@ void opj_t1_decode_cblks(opj_tcd_t* tcd,
 
                         /* TODO: remove this once we don't iterate over */
                         /* tile pixels that are not in the subwindow of interest */
-                        OPJ_UINT32 j, i;
+                        OPJ_UINT32 j;
                         OPJ_INT32 x = cblk->x0 - band->x0;
                         OPJ_INT32 y = cblk->y0 - band->y0;
                         OPJ_INT32* OPJ_RESTRICT tiledp;
@@ -1823,9 +1823,7 @@ void opj_t1_decode_cblks(opj_tcd_t* tcd,
                                                             (OPJ_UINT32)x];
 
                         for (j = 0; j < cblk_h; ++j) {
-                            for (i = 0; i < cblk_w; ++i) {
-                                ((OPJ_INT32*)tiledp)[(j * tile_w) + i] = 0;
-                            }
+                            memset(tiledp + j * tile_w, 0, cblk_w * sizeof(OPJ_INT32));
                         }
                         continue;
                     }

--- a/src/lib/openjp2/t1.h
+++ b/src/lib/openjp2/t1.h
@@ -230,7 +230,7 @@ OPJ_BOOL opj_t1_encode_cblks(opj_t1_t *t1,
 
 /**
 Decode the code-blocks of a tile
-@param tp Thread pool
+@param tcd TCD handle
 @param pret Pointer to return value
 @param tilec The tile to decode
 @param tccp Tile coding parameters
@@ -238,7 +238,7 @@ Decode the code-blocks of a tile
 @param p_manager_mutex mutex for the event manager
 @param check_pterm whether PTERM correct termination should be checked
 */
-void opj_t1_decode_cblks(opj_thread_pool_t* tp,
+void opj_t1_decode_cblks(opj_tcd_t* tcd,
                          volatile OPJ_BOOL* pret,
                          opj_tcd_tilecomp_t* tilec,
                          opj_tccp_t* tccp,

--- a/src/lib/openjp2/t2.h
+++ b/src/lib/openjp2/t2.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2005, Herve Drolon, FreeImage Team
  * Copyright (c) 2008, 2011-2012, Centre National d'Etudes Spatiales (CNES), FR
  * Copyright (c) 2012, CS Systemes d'Information, France
+ * Copyright (c) 2017, IntoPIX SA <support@intopix.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -94,6 +95,7 @@ OPJ_BOOL opj_t2_encode_packets(opj_t2_t* t2,
 
 /**
 Decode the packets of a tile from a source buffer
+@param tcd TCD handle
 @param t2 T2 handle
 @param tileno number that identifies the tile for which to decode the packets
 @param tile tile for which to decode the packets
@@ -105,7 +107,8 @@ Decode the packets of a tile from a source buffer
 
 @return FIXME DOC
  */
-OPJ_BOOL opj_t2_decode_packets(opj_t2_t *t2,
+OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
+                               opj_t2_t *t2,
                                OPJ_UINT32 tileno,
                                opj_tcd_tile_t *tile,
                                OPJ_BYTE *src,

--- a/src/lib/openjp2/tcd.c
+++ b/src/lib/openjp2/tcd.c
@@ -2381,6 +2381,14 @@ OPJ_BOOL opj_tcd_is_subband_area_of_interest(opj_tcd_t *tcd,
         OPJ_UINT32 band_x1,
         OPJ_UINT32 band_y1)
 {
+    /* Note: those values for filter_margin are in part the result of */
+    /* experimentation. The value 2 for QMFBID=1 (5x3 filter) can be linked */
+    /* to the maximum left/right extension given in tables F.2 and F.3 of the */
+    /* standard. The value 3 for QMFBID=0 (9x7 filter) is more suspicious, */
+    /* since F.2 and F.3 would lead to 4 instead, so the current 3 might be */
+    /* needed to be bumped to 4, in case inconsistencies are found while */
+    /* decoding parts of irreversible coded images. */
+    /* See opj_dwt_decode_partial_53 and opj_dwt_decode_partial_97 as well */
     OPJ_UINT32 filter_margin = (tcd->tcp->tccps[compno].qmfbid == 1) ? 2 : 3;
     opj_tcd_tilecomp_t *tilec = &(tcd->tcd_image->tiles->comps[compno]);
     opj_image_comp_t* image_comp = &(tcd->image->comps[compno]);

--- a/src/lib/openjp2/tcd.c
+++ b/src/lib/openjp2/tcd.c
@@ -1778,7 +1778,7 @@ static OPJ_BOOL opj_tcd_dwt_decode(opj_tcd_t *p_tcd)
         */
 
         if (l_tccp->qmfbid == 1) {
-            if (! opj_dwt_decode(p_tcd->thread_pool, l_tile_comp,
+            if (! opj_dwt_decode(p_tcd, l_tile_comp,
                                  l_img_comp->resno_decoded + 1)) {
                 return OPJ_FALSE;
             }

--- a/src/lib/openjp2/tcd.c
+++ b/src/lib/openjp2/tcd.c
@@ -1783,7 +1783,8 @@ static OPJ_BOOL opj_tcd_dwt_decode(opj_tcd_t *p_tcd)
                 return OPJ_FALSE;
             }
         } else {
-            if (! opj_dwt_decode_real(l_tile_comp, l_img_comp->resno_decoded + 1)) {
+            if (! opj_dwt_decode_real(p_tcd, l_tile_comp,
+                                      l_img_comp->resno_decoded + 1)) {
                 return OPJ_FALSE;
             }
         }

--- a/src/lib/openjp2/tcd.h
+++ b/src/lib/openjp2/tcd.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2005, Herve Drolon, FreeImage Team
  * Copyright (c) 2008, 2011-2012, Centre National d'Etudes Spatiales (CNES), FR
  * Copyright (c) 2012, CS Systemes d'Information, France
+ * Copyright (c) 2017, IntoPIX SA <support@intopix.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -180,6 +181,8 @@ typedef struct opj_tcd_resolution {
 typedef struct opj_tcd_tilecomp {
     /* dimension of component : left upper corner (x0, y0) right low corner (x1,y1) */
     OPJ_INT32 x0, y0, x1, y1;
+    /* component number */
+    OPJ_UINT32 compno;
     /* number of resolutions level */
     OPJ_UINT32 numresolutions;
     /* number of resolutions level to decode (at max)*/
@@ -252,6 +255,10 @@ typedef struct opj_tcd {
     OPJ_BITFIELD m_is_decoder : 1;
     /** Thread pool */
     opj_thread_pool_t* thread_pool;
+    OPJ_UINT32 decoded_x0;
+    OPJ_UINT32 decoded_y0;
+    OPJ_UINT32 decoded_x1;
+    OPJ_UINT32 decoded_y1;
 } opj_tcd_t;
 
 /** @name Exported functions */
@@ -348,6 +355,10 @@ OPJ_BOOL opj_tcd_encode_tile(opj_tcd_t *p_tcd,
 /**
 Decode a tile from a buffer into a raw image
 @param tcd TCD handle
+@param decoded_x0 Upper left x of region to decode (in grid coordinates)
+@param decoded_y0 Upper left y of region to decode (in grid coordinates)
+@param decoded_x1 Lower right x of region to decode (in grid coordinates)
+@param decoded_y1 Lower right y of region to decode (in grid coordinates)
 @param src Source buffer
 @param len Length of source buffer
 @param tileno Number that identifies one of the tiles to be decoded
@@ -355,6 +366,10 @@ Decode a tile from a buffer into a raw image
 @param manager the event manager.
 */
 OPJ_BOOL opj_tcd_decode_tile(opj_tcd_t *tcd,
+                             OPJ_UINT32 decoded_x0,
+                             OPJ_UINT32 decoded_y0,
+                             OPJ_UINT32 decoded_x1,
+                             OPJ_UINT32 decoded_y1,
                              OPJ_BYTE *src,
                              OPJ_UINT32 len,
                              OPJ_UINT32 tileno,
@@ -408,6 +423,31 @@ OPJ_BOOL opj_tcd_is_band_empty(opj_tcd_band_t* band);
 
 /** Reinitialize a segment */
 void opj_tcd_reinit_segment(opj_tcd_seg_t* seg);
+
+
+/** Returns whether a sub-band region contributes to the area of interest
+ * tcd->decoded_x0,tcd->decoded_y0,tcd->decoded_x1,tcd->decoded_y1.
+ *
+ * @param tcd    TCD handle.
+ * @param compno Component number
+ * @param resno  Resolution number
+ * @param bandno Band number (*not* band index, ie 0, 1, 2 or 3)
+ * @param x0     Upper left x in subband coordinates
+ * @param y0     Upper left y in subband coordinates
+ * @param x1     Lower right x in subband coordinates
+ * @param y1     Lower right y in subband coordinates
+ * @return OPJ_TRUE whether the sub-band region contributs to the area of
+ *                  interest.
+ */
+OPJ_BOOL opj_tcd_is_subband_area_of_interest(opj_tcd_t *tcd,
+        OPJ_UINT32 compno,
+        OPJ_UINT32 resno,
+        OPJ_UINT32 bandno,
+        OPJ_UINT32 x0,
+        OPJ_UINT32 y0,
+        OPJ_UINT32 x1,
+        OPJ_UINT32 y1);
+
 
 /* ----------------------------------------------------------------------- */
 /*@}*/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,9 @@ add_executable(compare_raw_files ${compare_raw_files_SRCS})
 add_executable(test_tile_encoder test_tile_encoder.c)
 target_link_libraries(test_tile_encoder ${OPENJPEG_LIBRARY_NAME})
 
+add_executable(test_decode_area test_decode_area.c)
+target_link_libraries(test_decode_area ${OPENJPEG_LIBRARY_NAME})
+
 # Let's try a couple of possibilities:
 add_test(NAME tte0 COMMAND test_tile_encoder)
 add_test(NAME tte1 COMMAND test_tile_encoder 3 2048 2048 1024 1024 8 1 tte1.j2k)
@@ -79,6 +82,18 @@ add_test(NAME rta4 COMMAND j2k_random_tile_access tte4.j2k)
 set_property(TEST rta4 APPEND PROPERTY DEPENDS tte4)
 add_test(NAME rta5 COMMAND j2k_random_tile_access tte5.j2k)
 set_property(TEST rta5 APPEND PROPERTY DEPENDS tte5)
+
+add_test(NAME tda_prep_reversible_no_precinct COMMAND test_tile_encoder 1 256 256 32 32 8 0 reversible_no_precinct.j2k 4 4 3 0 0 1)
+add_test(NAME tda_reversible_no_precinct COMMAND test_decode_area -q reversible_no_precinct.j2k)
+set_property(TEST tda_reversible_no_precinct APPEND PROPERTY DEPENDS tda_prep_reversible_no_precinct)
+
+add_test(NAME tda_prep_reversible_with_precinct COMMAND test_tile_encoder 1 256 256 32 32 8 0 reversible_with_precinct.j2k 4 4 3 0 0 1 16 16)
+add_test(NAME tda_reversible_with_precinct COMMAND test_decode_area -q reversible_with_precinct.j2k)
+set_property(TEST tda_reversible_with_precinct APPEND PROPERTY DEPENDS tda_prep_reversible_with_precinct)
+
+add_test(NAME tda_prep_irreversible_no_precinct COMMAND test_tile_encoder 1 256 256 32 32 8 1 irreversible_no_precinct.j2k 4 4 3 0 0 1)
+add_test(NAME tda_irreversible_no_precinct COMMAND test_decode_area -q irreversible_no_precinct.j2k)
+set_property(TEST tda_irreversible_no_precinct APPEND PROPERTY DEPENDS tda_prep_irreversible_no_precinct)
 
 add_executable(include_openjpeg include_openjpeg.c)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,10 @@ add_test(NAME tda_prep_reversible_no_precinct COMMAND test_tile_encoder 1 256 25
 add_test(NAME tda_reversible_no_precinct COMMAND test_decode_area -q reversible_no_precinct.j2k)
 set_property(TEST tda_reversible_no_precinct APPEND PROPERTY DEPENDS tda_prep_reversible_no_precinct)
 
+add_test(NAME tda_prep_reversible_203_201_17_19_no_precinct COMMAND test_tile_encoder 1 203 201 17 19 8 0 reversible_203_201_17_19_no_precinct.j2k 4 4 3 0 0 1)
+add_test(NAME tda_reversible_203_201_17_19_no_precinct COMMAND test_decode_area -q reversible_203_201_17_19_no_precinct.j2k)
+set_property(TEST tda_reversible_203_201_17_19_no_precinct APPEND PROPERTY DEPENDS tda_prep_reversible_203_201_17_19_no_precinct)
+
 add_test(NAME tda_prep_reversible_with_precinct COMMAND test_tile_encoder 1 256 256 32 32 8 0 reversible_with_precinct.j2k 4 4 3 0 0 1 16 16)
 add_test(NAME tda_reversible_with_precinct COMMAND test_decode_area -q reversible_with_precinct.j2k)
 set_property(TEST tda_reversible_with_precinct APPEND PROPERTY DEPENDS tda_prep_reversible_with_precinct)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,6 +99,10 @@ add_test(NAME tda_prep_irreversible_no_precinct COMMAND test_tile_encoder 1 256 
 add_test(NAME tda_irreversible_no_precinct COMMAND test_decode_area -q irreversible_no_precinct.j2k)
 set_property(TEST tda_irreversible_no_precinct APPEND PROPERTY DEPENDS tda_prep_irreversible_no_precinct)
 
+add_test(NAME tda_prep_irreversible_203_201_17_19_no_precinct COMMAND test_tile_encoder 1 203 201 17 19 8 1 irreversible_203_201_17_19_no_precinct.j2k 4 4 3 0 0 1)
+add_test(NAME tda_irreversible_203_201_17_19_no_precinct COMMAND test_decode_area -q irreversible_203_201_17_19_no_precinct.j2k)
+set_property(TEST tda_irreversible_203_201_17_19_no_precinct APPEND PROPERTY DEPENDS tda_prep_irreversible_203_201_17_19_no_precinct)
+
 add_executable(include_openjpeg include_openjpeg.c)
 
 # No image send to the dashboard if lib PNG is not available.

--- a/tests/test_decode_area.c
+++ b/tests/test_decode_area.c
@@ -1,0 +1,394 @@
+/*
+ * The copyright in this software is being made available under the 2-clauses
+ * BSD License, included below. This software may be subject to other third
+ * party and contributor rights, including patent rights, and no such rights
+ * are granted under this license.
+ *
+ * Copyright (c) 2017, IntoPix SA <contact@intopix.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS `AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "openjpeg.h"
+#include "format_defs.h"
+
+
+/* -------------------------------------------------------------------------- */
+#define JP2_RFC3745_MAGIC "\x00\x00\x00\x0c\x6a\x50\x20\x20\x0d\x0a\x87\x0a"
+#define JP2_MAGIC "\x0d\x0a\x87\x0a"
+/* position 45: "\xff\x52" */
+#define J2K_CODESTREAM_MAGIC "\xff\x4f\xff\x51"
+
+static int infile_format(const char *fname)
+{
+    FILE *reader;
+    unsigned char buf[12];
+    unsigned int l_nb_read;
+
+    reader = fopen(fname, "rb");
+
+    if (reader == NULL) {
+        return -1;
+    }
+
+    memset(buf, 0, 12);
+    l_nb_read = (unsigned int)fread(buf, 1, 12, reader);
+    fclose(reader);
+    if (l_nb_read != 12) {
+        return -1;
+    }
+
+    if (memcmp(buf, JP2_RFC3745_MAGIC, 12) == 0 || memcmp(buf, JP2_MAGIC, 4) == 0) {
+        return JP2_CFMT;
+    } else if (memcmp(buf, J2K_CODESTREAM_MAGIC, 4) == 0) {
+        return J2K_CFMT;
+    } else {
+        return -1;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+
+/**
+  sample error debug callback expecting no client object
+ */
+static void error_callback(const char *msg, void *client_data)
+{
+    (void)client_data;
+    fprintf(stdout, "[ERROR] %s", msg);
+}
+/**
+  sample warning debug callback expecting no client object
+ */
+static void warning_callback(const char *msg, void *client_data)
+{
+    (void)client_data;
+    fprintf(stdout, "[WARNING] %s", msg);
+}
+/**
+  sample debug callback expecting no client object
+ */
+static void info_callback(const char *msg, void *client_data)
+{
+    (void)client_data;
+    (void)msg;
+    /*fprintf(stdout, "[INFO] %s", msg);*/
+}
+
+opj_image_t* decode(
+    OPJ_BOOL quiet,
+    const char* input_file,
+    OPJ_INT32 x0,
+    OPJ_INT32 y0,
+    OPJ_INT32 x1,
+    OPJ_INT32 y1,
+    OPJ_UINT32* ptilew,
+    OPJ_UINT32* ptileh,
+    OPJ_UINT32* pcblkw,
+    OPJ_UINT32* pcblkh)
+{
+    opj_dparameters_t l_param;
+    opj_codec_t * l_codec = NULL;
+    opj_image_t * l_image = NULL;
+    opj_stream_t * l_stream = NULL;
+
+    if (!quiet) {
+        if (x0 != 0 || x1 != 0 || y0 != 0 || y1 != 0) {
+            printf("Decoding %d,%d,%d,%d\n", x0, y0, x1, y1);
+        } else {
+            printf("Decoding full image\n");
+        }
+    }
+
+    l_stream = opj_stream_create_default_file_stream(input_file, OPJ_TRUE);
+    if (!l_stream) {
+        fprintf(stderr, "ERROR -> failed to create the stream from the file\n");
+        return NULL;
+    }
+
+    /* Set the default decoding parameters */
+    opj_set_default_decoder_parameters(&l_param);
+
+    /* */
+    l_param.decod_format = infile_format(input_file);
+
+
+    switch (l_param.decod_format) {
+    case J2K_CFMT: { /* JPEG-2000 codestream */
+        /* Get a decoder handle */
+        l_codec = opj_create_decompress(OPJ_CODEC_J2K);
+        break;
+    }
+    case JP2_CFMT: { /* JPEG 2000 compressed image data */
+        /* Get a decoder handle */
+        l_codec = opj_create_decompress(OPJ_CODEC_JP2);
+        break;
+    }
+    default: {
+        fprintf(stderr, "ERROR -> Not a valid JPEG2000 file!\n");
+        opj_stream_destroy(l_stream);
+        return NULL;
+    }
+    }
+
+    /* catch events using our callbacks and give a local context */
+    opj_set_info_handler(l_codec, info_callback, 00);
+    opj_set_warning_handler(l_codec, warning_callback, 00);
+    opj_set_error_handler(l_codec, error_callback, 00);
+
+    /* Setup the decoder decoding parameters using user parameters */
+    if (! opj_setup_decoder(l_codec, &l_param)) {
+        fprintf(stderr, "ERROR ->failed to setup the decoder\n");
+        opj_stream_destroy(l_stream);
+        opj_destroy_codec(l_codec);
+        return NULL;
+    }
+
+    /* Read the main header of the codestream and if necessary the JP2 boxes*/
+    if (! opj_read_header(l_stream, l_codec, &l_image)) {
+        fprintf(stderr, "ERROR -> failed to read the header\n");
+        opj_stream_destroy(l_stream);
+        opj_destroy_codec(l_codec);
+        return NULL;
+    }
+
+    {
+        opj_codestream_info_v2_t* pCodeStreamInfo = opj_get_cstr_info(l_codec);
+        if (ptilew) {
+            *ptilew = pCodeStreamInfo->tdx;
+        }
+        if (ptileh) {
+            *ptilew = pCodeStreamInfo->tdy;
+        }
+        //int numResolutions = pCodeStreamInfo->m_default_tile_info.tccp_info[0].numresolutions;
+        if (pcblkw) {
+            *pcblkw = 1U << pCodeStreamInfo->m_default_tile_info.tccp_info[0].cblkw;
+        }
+        if (pcblkh) {
+            *pcblkh = 1U << pCodeStreamInfo->m_default_tile_info.tccp_info[0].cblkh;
+        }
+        opj_destroy_cstr_info(&pCodeStreamInfo);
+    }
+
+    if (x0 != 0 || x1 != 0 || y0 != 0 || y1 != 0) {
+        if (!opj_set_decode_area(l_codec, l_image, x0, y0, x1, y1)) {
+            fprintf(stderr, "ERROR -> failed to set the decoded area\n");
+            opj_stream_destroy(l_stream);
+            opj_destroy_codec(l_codec);
+            opj_image_destroy(l_image);
+            return NULL;
+        }
+    }
+
+    /* Get the decoded image */
+    if (!(opj_decode(l_codec, l_stream, l_image))) {
+        fprintf(stderr, "ERROR -> failed to decode image!\n");
+        opj_stream_destroy(l_stream);
+        opj_destroy_codec(l_codec);
+        opj_image_destroy(l_image);
+        return NULL;
+    }
+
+    if (! opj_end_decompress(l_codec, l_stream)) {
+        opj_stream_destroy(l_stream);
+        opj_destroy_codec(l_codec);
+        opj_image_destroy(l_image);
+        return NULL;
+    }
+
+
+    opj_stream_destroy(l_stream);
+    opj_destroy_codec(l_codec);
+    return l_image;
+}
+
+OPJ_BOOL check_consistency(opj_image_t* p_image, opj_image_t* p_sub_image)
+{
+    OPJ_UINT32 compno;
+    for (compno = 0; compno < p_image->numcomps; compno ++) {
+        OPJ_UINT32 y;
+        OPJ_UINT32 shift_y = p_sub_image->comps[compno].y0 - p_image->comps[compno].y0;
+        OPJ_UINT32 shift_x = p_sub_image->comps[compno].x0 - p_image->comps[compno].x0;
+        OPJ_UINT32 image_w = p_image->comps[compno].w;
+        OPJ_UINT32 sub_image_w = p_sub_image->comps[compno].w;
+        for (y = 0; y < p_sub_image->comps[compno].h; y++) {
+            OPJ_UINT32 x;
+
+            for (x = 0; x < sub_image_w; x++) {
+                OPJ_INT32 sub_image_val =
+                    p_sub_image->comps[compno].data[y * sub_image_w + x];
+                OPJ_INT32 image_val =
+                    p_image->comps[compno].data[(y + shift_y) * image_w + x + shift_x];
+                if (sub_image_val != image_val) {
+                    fprintf(stderr,
+                            "Difference found at subimage pixel (%u,%u) "
+                            "of compno=%u: got %d, expected %d\n",
+                            x, y, compno, sub_image_val, image_val);
+                    return OPJ_FALSE;
+                }
+            }
+        }
+    }
+    return OPJ_TRUE;
+}
+
+static INLINE OPJ_UINT32 opj_uint_min(OPJ_UINT32  a, OPJ_UINT32  b)
+{
+    return (a < b) ? a : b;
+}
+
+int main(int argc, char** argv)
+{
+    opj_image_t * l_image = NULL;
+    opj_image_t * l_sub_image = NULL;
+    OPJ_INT32 da_x0 = 0, da_y0 = 0, da_x1 = 0, da_y1 = 0;
+    const char* input_file = NULL;
+    OPJ_UINT32 tilew, tileh, cblkw, cblkh;
+    OPJ_UINT32 w, h;
+    OPJ_UINT32 x, y;
+    OPJ_UINT32 step_x, step_y;
+    OPJ_BOOL quiet = OPJ_FALSE;
+    OPJ_UINT32 nsteps = 100;
+
+    if (argc < 2) {
+        fprintf(stderr,
+                "Usage: test_decode_area [-q] [-steps n] input_file_jp2_or_jk2 [x0 y0 x1 y1]\n");
+        return 1;
+    }
+
+    {
+        int iarg;
+        for (iarg = 1; iarg < argc; iarg++) {
+            if (strcmp(argv[iarg], "-q") == 0) {
+                quiet = OPJ_TRUE;
+            } else if (strcmp(argv[iarg], "-steps") == 0 && iarg + 1 < argc) {
+                nsteps = (OPJ_UINT32)atoi(argv[iarg + 1]);
+                iarg ++;
+            } else if (input_file == NULL) {
+                input_file = argv[iarg];
+            } else if (iarg + 3 < argc) {
+                da_x0 = atoi(argv[iarg]);
+                da_y0 = atoi(argv[iarg + 1]);
+                da_x1 = atoi(argv[iarg + 2]);
+                da_y1 = atoi(argv[iarg + 3]);
+                iarg += 3;
+            }
+        }
+    }
+
+    l_image = decode(quiet, input_file, 0, 0, 0, 0,
+                     &tilew, &tileh, &cblkw, &cblkh);
+    if (!l_image) {
+        return 1;
+    }
+
+    if (da_x0 != 0 || da_x1 != 0 || da_y0 != 0 || da_y1 != 0) {
+        l_sub_image = decode(quiet, input_file, da_x0, da_y0, da_x1, da_y1,
+                             NULL, NULL, NULL, NULL);
+        if (!l_sub_image) {
+            fprintf(stderr, "decode failed for %d,%d,%d,%d\n",
+                    da_x0, da_y0, da_x1, da_y1);
+            opj_image_destroy(l_sub_image);
+            opj_image_destroy(l_image);
+            return 1;
+        }
+
+        if (!check_consistency(l_image, l_sub_image)) {
+            fprintf(stderr, "Consistency checked failed for %d,%d,%d,%d\n",
+                    da_x0, da_y0, da_x1, da_y1);
+            opj_image_destroy(l_sub_image);
+            opj_image_destroy(l_image);
+            return 1;
+        }
+        opj_image_destroy(l_sub_image);
+        opj_image_destroy(l_image);
+        return 0;
+    }
+
+    w = l_image->x1 - l_image->x0;
+    h = l_image->y1 - l_image->y0;
+    step_x = w > nsteps ? w / nsteps : 1;
+    step_y = h > nsteps ? h / nsteps : 1;
+    for (y = 0; y < h; y += step_y) {
+        for (x = 0; x < w; x += step_x) {
+            da_x0 = (OPJ_INT32)(l_image->x0 + x);
+            da_y0 = (OPJ_INT32)(l_image->y0 + y);
+            da_x1 = (OPJ_INT32)opj_uint_min(l_image->x1, l_image->x0 + x + 1);
+            da_y1 = (OPJ_INT32)opj_uint_min(l_image->y1, l_image->y0 + y + 1);
+            l_sub_image = decode(quiet, input_file, da_x0, da_y0, da_x1, da_y1,
+                                 NULL, NULL, NULL, NULL);
+            if (!l_sub_image) {
+                fprintf(stderr, "decode failed for %d,%d,%d,%d\n",
+                        da_x0, da_y0, da_x1, da_y1);
+                opj_image_destroy(l_sub_image);
+                opj_image_destroy(l_image);
+                return 1;
+            }
+
+            if (!check_consistency(l_image, l_sub_image)) {
+                fprintf(stderr, "Consistency checked failed for %d,%d,%d,%d\n",
+                        da_x0, da_y0, da_x1, da_y1);
+                opj_image_destroy(l_sub_image);
+                opj_image_destroy(l_image);
+                return 1;
+            }
+            opj_image_destroy(l_sub_image);
+
+            if (step_x > 1 || step_y > 1) {
+                if (step_x > 1) {
+                    da_x0 = (OPJ_INT32)opj_uint_min(l_image->x1, (OPJ_UINT32)da_x0 + 1);
+                    da_x1 = (OPJ_INT32)opj_uint_min(l_image->x1, (OPJ_UINT32)da_x1 + 1);
+                }
+                if (step_y > 1) {
+                    da_y0 = (OPJ_INT32)opj_uint_min(l_image->y1, (OPJ_UINT32)da_y0 + 1);
+                    da_y1 = (OPJ_INT32)opj_uint_min(l_image->y1, (OPJ_UINT32)da_y1 + 1);
+                }
+                l_sub_image = decode(quiet, input_file, da_x0, da_y0, da_x1, da_y1,
+                                     NULL, NULL, NULL, NULL);
+                if (!l_sub_image) {
+                    fprintf(stderr, "decode failed for %d,%d,%d,%d\n",
+                            da_x0, da_y0, da_x1, da_y1);
+                    opj_image_destroy(l_sub_image);
+                    opj_image_destroy(l_image);
+                    return 1;
+                }
+
+                if (!check_consistency(l_image, l_sub_image)) {
+                    fprintf(stderr, "Consistency checked failed for %d,%d,%d,%d\n",
+                            da_x0, da_y0, da_x1, da_y1);
+                    opj_image_destroy(l_sub_image);
+                    opj_image_destroy(l_image);
+                    return 1;
+                }
+                opj_image_destroy(l_sub_image);
+            }
+        }
+    }
+
+    opj_image_destroy(l_image);
+    return 0;
+}

--- a/tests/test_decode_area.c
+++ b/tests/test_decode_area.c
@@ -367,24 +367,26 @@ int main(int argc, char** argv)
                     da_y0 = (OPJ_INT32)opj_uint_min(l_image->y1, (OPJ_UINT32)da_y0 + 1);
                     da_y1 = (OPJ_INT32)opj_uint_min(l_image->y1, (OPJ_UINT32)da_y1 + 1);
                 }
-                l_sub_image = decode(quiet, input_file, da_x0, da_y0, da_x1, da_y1,
-                                     NULL, NULL, NULL, NULL);
-                if (!l_sub_image) {
-                    fprintf(stderr, "decode failed for %d,%d,%d,%d\n",
-                            da_x0, da_y0, da_x1, da_y1);
-                    opj_image_destroy(l_sub_image);
-                    opj_image_destroy(l_image);
-                    return 1;
-                }
+                if (da_x0 < (OPJ_INT32)l_image->x1 && da_y0 < (OPJ_INT32)l_image->y1) {
+                    l_sub_image = decode(quiet, input_file, da_x0, da_y0, da_x1, da_y1,
+                                         NULL, NULL, NULL, NULL);
+                    if (!l_sub_image) {
+                        fprintf(stderr, "decode failed for %d,%d,%d,%d\n",
+                                da_x0, da_y0, da_x1, da_y1);
+                        opj_image_destroy(l_sub_image);
+                        opj_image_destroy(l_image);
+                        return 1;
+                    }
 
-                if (!check_consistency(l_image, l_sub_image)) {
-                    fprintf(stderr, "Consistency checked failed for %d,%d,%d,%d\n",
-                            da_x0, da_y0, da_x1, da_y1);
+                    if (!check_consistency(l_image, l_sub_image)) {
+                        fprintf(stderr, "Consistency checked failed for %d,%d,%d,%d\n",
+                                da_x0, da_y0, da_x1, da_y1);
+                        opj_image_destroy(l_sub_image);
+                        opj_image_destroy(l_image);
+                        return 1;
+                    }
                     opj_image_destroy(l_sub_image);
-                    opj_image_destroy(l_image);
-                    return 1;
                 }
-                opj_image_destroy(l_sub_image);
             }
         }
     }


### PR DESCRIPTION
Continuation of https://github.com/uclouvain/openjpeg/pull/990 (although in theory it could be applied independantly, but in practice stage2 only makes sense with stage1).

This lowers 'bin/opj_decompress -i ../MAPA.jp2 -o out.tif -d 0,0,256,256'  down to 0.860s (IDWT 5x3 case)

Note: for IDWT 5x3 the function that does subtile decoding doesn't use the recent SSE2/AVX2 optimizations