### PR TITLE
Fix crash on Windows by using opj_image_data_free instead of opj_free

### DIFF
--- a/src/lib/openjp2/image.c
+++ b/src/lib/openjp2/image.c
@@ -180,7 +180,7 @@ void opj_copy_image_header(const opj_image_t* p_image_src,
         for (compno = 0; compno < p_image_dest->numcomps; compno++) {
             opj_image_comp_t *image_comp = &(p_image_dest->comps[compno]);
             if (image_comp->data) {
-                opj_free(image_comp->data);
+                opj_image_data_free(image_comp->data);
             }
         }
         opj_free(p_image_dest->comps);

--- a/src/lib/openjp2/jp2.c
+++ b/src/lib/openjp2/jp2.c
@@ -1083,7 +1083,7 @@ static OPJ_BOOL opj_jp2_apply_pclr(opj_image_t *image,
         if (!new_comps[i].data) {
             while (i > 0) {
                 -- i;
-                opj_free(new_comps[i].data);
+                opj_image_data_free(new_comps[i].data);
             }
             opj_free(new_comps);
             opj_event_msg(p_manager, EVT_ERROR,

--- a/src/lib/openmj2/jp2.c
+++ b/src/lib/openmj2/jp2.c
@@ -426,7 +426,7 @@ static void jp2_apply_pclr(opj_jp2_color_t *color, opj_image_t *image,
     max = image->numcomps;
     for (i = 0; i < max; ++i) {
         if (old_comps[i].data) {
-            opj_free(old_comps[i].data);
+            opj_image_data_free(old_comps[i].data);
         }
     }
     opj_free(old_comps);


### PR DESCRIPTION
Fix crash on Windows by using ``opj_image_data_free`` instead of ``opj_free`` for ``image->comps[].data``
Issue: (https://github.com/uclouvain/openjpeg/issues/1014)