### PR TITLE
CMakeLists.txt: Don't require a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 #string(TOLOWER ${OPENJPEG_NAMESPACE} OPENJPEG_LIBRARY_NAME)
 set(OPENJPEG_LIBRARY_NAME openjp2)
 
-project(${OPENJPEG_NAMESPACE})
+project(${OPENJPEG_NAMESPACE} C)
 
 # Do full dependency headers.
 include_regular_expression("^.*$")


### PR DESCRIPTION
By default, CMake assumes that the project is using both C and C++.  By
explicitly passing 'C' as argument of the project() macro, we tell CMake
that only C is used, which prevents CMake from erroring out if a C++
compiler doesn't exist.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>