### PR TITLE
Fix resource leak (CID 179466)

### DIFF
--- a/src/bin/jp2/convert.c
+++ b/src/bin/jp2/convert.c
@@ -1416,6 +1416,9 @@ int imagetopgx(opj_image_t * image, const char *outfile)
             unsigned char* line_buffer = malloc((size_t)w);
             if (line_buffer == NULL) {
                 fprintf(stderr, "Out of memory");
+                if (total > 256) {
+                    free(name);
+                }
                 goto fin;
             }
             for (j = 0; j < h; j++) {


### PR DESCRIPTION
Coverity report:

CID 179466 (#1 of 1): Resource leak (RESOURCE_LEAK)
93. leaked_storage: Variable name going out of scope leaks the storage it points to.

Signed-off-by: Stefan Weil <sw@weilnetz.de>