### PR TITLE
Note that seek uses SEEK_SET behavior.

### DIFF
--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -1178,7 +1178,8 @@ OPJ_API void OPJ_CALLCONV opj_stream_set_skip_function(opj_stream_t* p_stream,
         opj_stream_skip_fn p_function);
 
 /**
- * Sets the given function to be used as a seek function, the stream is then seekable.
+ * Sets the given function to be used as a seek function, the stream is then seekable,
+ * using SEEK_SET behavior.
  * @param       p_stream    the stream to modify
  * @param       p_function  the function to use a skip function.
 */


### PR DESCRIPTION
Edit docstring, I lost some hours on this because I'd assumed seek used `SEEK_CUR` behavior, and even had images loading once OPJ_DISABLE_TPSOT_FIX was defined.

A comment like this would have helped.