### PR TITLE
In case of an error in opj_decompress, the output file is deleted only if it's a regular file

### DIFF
--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -69,6 +69,8 @@
 
 #ifdef OPJ_HAVE_LIBLCMS2
 #include <lcms2.h>
+#include <sys/stat.h>
+
 #endif
 #ifdef OPJ_HAVE_LIBLCMS1
 #include <lcms.h>
@@ -1785,7 +1787,15 @@ int main(int argc, char **argv)
         /* destroy the codestream index */
         opj_destroy_cstr_index(&cstr_index);
 
-        if (failed) {
+        /* delete the destination file, if it's a regular file */
+        struct stat info;
+        int retval = lstat(parameters.outfile, &info);
+        int file = 1;
+        if (retval >= 0) {
+            file = S_ISREG(info.st_mode);
+        }
+
+        if (failed && file != 0) {
             (void)remove(parameters.outfile);    /* ignore return value */
         }
     }


### PR DESCRIPTION
I need to stream output from `opj_decompress` by invoking it like:
```
ln -s /dev/stdout stdout.bmp
opj_decompres -i image.jp2 -o stdout.bmp > output.bmp
```
This patch will prevent `opj_decompress` from deleting symlinks or any other non-regular files in the event of an error.