### PR TITLE
mj2: Add missing variable to format string in fprintf() invocation in meta_out.c

### DIFF
--- a/src/bin/mj2/meta_out.c
+++ b/src/bin/mj2/meta_out.c
@@ -846,7 +846,7 @@ void xml_write_mdia(FILE* file, FILE* xmlout, mj2_tk_t *track,
         }
         for (i = 0; i < 4; i++) {
             uint_to_chars(track->url[track->num_url].location[i], buf);
-            fprintf(xmlout,  "              <Location>%s</Location>\n");
+            fprintf(xmlout,  "              <Location>%s</Location>\n", buf);
         }
         fprintf(xmlout,
                 "            </DataEntryUrlBox>\n"); // table w. flags, URLs, URNs
@@ -868,7 +868,7 @@ void xml_write_mdia(FILE* file, FILE* xmlout, mj2_tk_t *track,
         fprintf(xmlout,  "              <Location>");
         for (i = 0; i < 4; i++) {
             uint_to_chars(track->urn[track->num_urn].location[i], buf);
-            fprintf(xmlout, "%s");
+            fprintf(xmlout, "%s", buf);
         }
         fprintf(xmlout,  "</Location>\n");
         fprintf(xmlout,  "            </DataEntryUrnBox>\n");


### PR DESCRIPTION
This adds the appropriate variables to the invocation of fprintf(). They were
specified in the format string, but were missing in the actual call. This
fixes #1074 and #1075.