### PR TITLE
opj_mj2_extract: Check provided output prefix for length

### DIFF
--- a/src/bin/mj2/opj_mj2_extract.c
+++ b/src/bin/mj2/opj_mj2_extract.c
@@ -140,7 +140,12 @@ int main(int argc, char *argv[])
         fread(frame_codestream, sample->sample_size - 8, 1,
               file); /* Assuming that jp and ftyp markers size do*/
 
-        sprintf(outfilename, "%s_%05d.j2k", argv[2], snum);
+        int num = snprintf(outfilename, sizeof(outfilename), "%s_%05d.j2k", argv[2], snum);
+        if (num >= sizeof(outfilename)) {
+            fprintf(stderr, "maximum length of output prefix exceeded\n");
+            return 1;
+        }
+
         outfile = fopen(outfilename, "wb");
         if (!outfile) {
             fprintf(stderr, "failed to open %s for writing\n", outfilename);


### PR DESCRIPTION
This uses snprintf() with correct buffer length instead of sprintf(), which
prevents a buffer overflow when providing a long output prefix. Furthermore
the program exits with an error when the provided output prefix is too long.

Fixes #1088.