### PR TITLE
opj_mj2_extract: Rename output_location to output_prefix

### DIFF
--- a/src/bin/mj2/opj_mj2_extract.c
+++ b/src/bin/mj2/opj_mj2_extract.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     mj2_dparameters_t parameters;
 
     if (argc != 3) {
-        printf("Usage: %s mj2filename output_location\n", argv[0]);
+        printf("Usage: %s mj2filename output_prefix\n", argv[0]);
         printf("Example: %s foreman.mj2 output/foreman\n", argv[0]);
         return 1;
     }


### PR DESCRIPTION
This renames the argument in the help output, as the latter better describes
the the purpose of this argument.