### PR TITLE
Fix an out-of-bounds read in imagetopgx()

### DIFF
--- a/src/bin/jp2/convert.c
+++ b/src/bin/jp2/convert.c
@@ -1372,8 +1372,10 @@ int imagetopgx(opj_image_t * image, const char *outfile)
         const size_t dotpos = olen - 4;
         const size_t total = dotpos + 1 + 1 + 4; /* '-' + '[1-3]' + '.pgx' */
 
-        if (outfile[dotpos] != '.') {
-            /* `pgx` was recognized but there is no dot at expected position */
+        if (olen < 5 || outfile[dotpos] != '.') {
+            /* `pgx` was recognized but there is no dot at expected position
+                or outfile is too short to contain anything meaningful other
+                than the file extension `.pgx` itself */
             fprintf(stderr, "ERROR -> Impossible happen.");
             goto fin;
         }


### PR DESCRIPTION
In case this function is invoked with a short outfile, a out-of-bounds read
will occur. This is currently not possible with opj_decompress, as this case
is intercepted in `get_file_format()` in `src/bin/jp2/opj_decompress.c`,
nevertheless it is not nice and robost code.

This fixes #1069.