### PR TITLE
jp3d: Replace sprintf() by snprintf() in volumetobin()

### DIFF
--- a/src/bin/jp3d/convert.c
+++ b/src/bin/jp3d/convert.c
@@ -788,7 +788,7 @@ int volumetobin(opj_volume_t * volume, char *outfile)
 
     fclose(fdest);
 
-    sprintf(name, "%s.img", outfile);
+    snprintf(name, sizeof(name), "%s.img", outfile);
     fimgdest = fopen(name, "w");
     if (!fimgdest) {
         fprintf(stdout, "[ERROR] Failed to open %s for writing\n", name);


### PR DESCRIPTION
This replaces the unsafe sprintf() invocation by the safer snprintf()
one, with the correct buffer size to prevent buffer overflows.

This fixes #1085.