### PR TITLE
Use local type declaration for POSIX standard type only for MS compiler

### DIFF
--- a/src/lib/openjpip/sock_manager.c
+++ b/src/lib/openjpip/sock_manager.c
@@ -30,7 +30,9 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#ifdef _MSC_VER
 typedef SSIZE_T ssize_t;
+#endif
 #else
 #include <sys/types.h>
 #include <sys/socket.h>


### PR DESCRIPTION
ssize_t is a POSIX type which is declared in POSIX include files.
Mingw-w64 provides it also for Windows.

Use the local declaration only with MS compilers.

Signed-off-by: Stefan Weil <sw@weilnetz.de>