### PR TITLE
Fix some typos in code comments and documentation

### DIFF
--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -134,7 +134,7 @@ typedef struct opj_decompress_params {
     /** Verbose mode */
     OPJ_BOOL m_verbose;
 
-    /** tile number ot the decoded tile*/
+    /** tile number of the decoded tile */
     OPJ_UINT32 tile_index;
     /** Nb of tile to decode */
     OPJ_UINT32 nb_tile_to_decode;

--- a/src/bin/mj2/opj_mj2_compress.c
+++ b/src/bin/mj2/opj_mj2_compress.c
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
 
     /*
         configure the event callbacks (not required)
-        setting of each callback is optionnal
+        setting of each callback is optional
     */
     memset(&event_mgr, 0, sizeof(opj_event_mgr_t));
     event_mgr.error_handler = error_callback;

--- a/src/lib/openjp2/dwt.c
+++ b/src/lib/openjp2/dwt.c
@@ -974,7 +974,7 @@ static void opj_idwt53_v(const opj_dwt_t *dwt,
 #if (defined(__SSE2__) || defined(__AVX2__))
         if (len > 1 && nb_cols == PARALLEL_COLS_53) {
             /* Same as below general case, except that thanks to SSE2/AVX2 */
-            /* we can efficently process 8/16 columns in parallel */
+            /* we can efficiently process 8/16 columns in parallel */
             opj_idwt53_v_cas0_mcols_SSE2_OR_AVX2(dwt->mem, sn, len, tiledp_col, stride);
             return;
         }
@@ -1017,7 +1017,7 @@ static void opj_idwt53_v(const opj_dwt_t *dwt,
 #if (defined(__SSE2__) || defined(__AVX2__))
         if (len > 2 && nb_cols == PARALLEL_COLS_53) {
             /* Same as below general case, except that thanks to SSE2/AVX2 */
-            /* we can efficently process 8/16 columns in parallel */
+            /* we can efficiently process 8/16 columns in parallel */
             opj_idwt53_v_cas1_mcols_SSE2_OR_AVX2(dwt->mem, sn, len, tiledp_col, stride);
             return;
         }
@@ -2041,7 +2041,7 @@ static OPJ_BOOL opj_dwt_decode_partial_tile(
         tr_hl_x0 = (OPJ_UINT32)tr->bands[0].x0;
         tr_lh_y0 = (OPJ_UINT32)tr->bands[1].y0;
 
-        /* Substract the origin of the bands for this tile, to the subwindow */
+        /* Subtract the origin of the bands for this tile, to the subwindow */
         /* of interest band coordinates, so as to get them relative to the */
         /* tile */
         win_ll_x0 = opj_uint_subs(win_ll_x0, tr_ll_x0);
@@ -2759,7 +2759,7 @@ OPJ_BOOL opj_dwt_decode_partial_97(opj_tcd_tilecomp_t* OPJ_RESTRICT tilec,
         tr_hl_x0 = (OPJ_UINT32)tr->bands[0].x0;
         tr_lh_y0 = (OPJ_UINT32)tr->bands[1].y0;
 
-        /* Substract the origin of the bands for this tile, to the subwindow */
+        /* Subtract the origin of the bands for this tile, to the subwindow */
         /* of interest band coordinates, so as to get them relative to the */
         /* tile */
         win_ll_x0 = opj_uint_subs(win_ll_x0, tr_ll_x0);

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -548,7 +548,7 @@ typedef struct opj_dparameters {
     /** Verbose mode */
     OPJ_BOOL m_verbose;
 
-    /** tile number ot the decoded tile*/
+    /** tile number of the decoded tile */
     OPJ_UINT32 tile_index;
     /** Nb of tile to decode */
     OPJ_UINT32 nb_tile_to_decode;
@@ -1385,7 +1385,7 @@ OPJ_API OPJ_BOOL OPJ_CALLCONV opj_set_decoded_components(opj_codec_t *p_codec,
  * performance improvements when reading an image by chunks.
  *
  * @param   p_codec         the jpeg2000 codec.
- * @param   p_image         the decoded image previously setted by opj_read_header
+ * @param   p_image         the decoded image previously set by opj_read_header
  * @param   p_start_x       the left position of the rectangle to decode (in image coordinates).
  * @param   p_end_x         the right position of the rectangle to decode (in image coordinates).
  * @param   p_start_y       the up position of the rectangle to decode (in image coordinates).

--- a/src/lib/openmj2/mj2.c
+++ b/src/lib/openmj2/mj2.c
@@ -534,7 +534,7 @@ void mj2_write_stsz(mj2_tk_t * tk, opj_cio_t *cio)
 
     else {
         cio_write(cio, 0,
-                  4);       /* Sample Size = 0 becase they all have different sizes */
+                  4);       /* Sample Size = 0 because they all have different sizes */
 
         cio_write(cio, tk->num_samples, 4); /* Sample Count */
 

--- a/src/lib/openmj2/tcd.h
+++ b/src/lib/openmj2/tcd.h
@@ -114,7 +114,7 @@ typedef struct opj_tcd_precinct {
     int x0, y0, x1,
         y1;       /* dimension of the precinct : left upper corner (x0, y0) right low corner (x1,y1) */
     int cw, ch;           /* number of precinct in width and height */
-    union {       /* code-blocks informations */
+    union {       /* code-blocks information */
         opj_tcd_cblk_enc_t* enc;
         opj_tcd_cblk_dec_t* dec;
     } cblks;

--- a/thirdparty/README.txt
+++ b/thirdparty/README.txt
@@ -5,5 +5,5 @@ They are solely provided for ease of build of OpenJPEG on system where those
 3rd party libs are not easily accessible (typically non-UNIX).
 
 The OpenJPEG does not recommend using those 3rd party libs over your system
-installed libs. The OpenJPEG does not even garantee that those libraries will
+installed libs. The OpenJPEG does not even guarantee that those libraries will
 work for you.


### PR DESCRIPTION
All typos were found by Codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>