### PR TITLE
Fix buffer overflows in jp2/jpwl compress/decompress

### DIFF
--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -654,9 +654,13 @@ static int parse_cmdline_encoder(int argc, char **argv,
         case 'O': {         /* output format */
             char outformat[50];
             char *of = opj_optarg;
-            sprintf(outformat, ".%s", of);
-            img_fol->set_out_format = 1;
-            parameters->cod_format = get_file_format(outformat);
+            if (strlen(opj_optarg) < sizeof(outformat)) {
+                sprintf(outformat, ".%s", of);
+                img_fol->set_out_format = 1;
+                parameters->cod_format = get_file_format(outformat);
+	    } else {
+	        parameters->cod_format = -1;
+	    }
             switch (parameters->cod_format) {
             case J2K_CFMT:
             case JP2_CFMT:

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -662,9 +662,13 @@ int parse_cmdline_decoder(int argc, char **argv,
         case 'O': {         /* output format */
             char outformat[50];
             char *of = opj_optarg;
-            sprintf(outformat, ".%s", of);
-            img_fol->set_out_format = 1;
-            parameters->cod_format = get_file_format(outformat);
+            if (strlen(opj_optarg) < sizeof(outformat)) {
+	      sprintf(outformat, ".%s", of);
+	      img_fol->set_out_format = 1;
+	      parameters->cod_format = get_file_format(outformat);
+	    } else {
+	      parameters->cod_format = -1;
+	    }
             switch (parameters->cod_format) {
             case PGX_DFMT:
                 img_fol->out_format = "pgx";

--- a/src/bin/jpwl/opj_jpwl_compress.c
+++ b/src/bin/jpwl/opj_jpwl_compress.c
@@ -768,9 +768,13 @@ static int parse_cmdline_encoder(int argc, char **argv,
         case 'O': {         /* output format */
             char outformat[50];
             char *of = opj_optarg;
-            sprintf(outformat, ".%s", of);
-            img_fol->set_out_format = 1;
-            parameters->cod_format = get_file_format(outformat);
+	    if (strlen(opj_optarg) < sizeof(outformat)) {
+	      sprintf(outformat, ".%s", of);
+	      img_fol->set_out_format = 1;
+	      parameters->cod_format = get_file_format(outformat);
+            } else {
+	      parameters->cod_format = -1;
+            }
             switch (parameters->cod_format) {
             case J2K_CFMT:
             case JP2_CFMT:

--- a/src/bin/jpwl/opj_jpwl_decompress.c
+++ b/src/bin/jpwl/opj_jpwl_decompress.c
@@ -345,9 +345,13 @@ int parse_cmdline_decoder(int argc, char **argv, opj_dparameters_t *parameters,
         case 'O': {         /* output format */
             char outformat[50];
             char *of = opj_optarg;
-            sprintf(outformat, ".%s", of);
-            img_fol->set_out_format = 1;
-            parameters->cod_format = get_file_format(outformat);
+            if (strlen(opj_optarg) < sizeof(outformat)) {
+	      sprintf(outformat, ".%s", of);
+	      img_fol->set_out_format = 1;
+	      parameters->cod_format = get_file_format(outformat);
+            } else {
+	      parameters->cod_format = -1;
+            }
             switch (parameters->cod_format) {
             case PGX_DFMT:
                 img_fol->out_format = "pgx";


### PR DESCRIPTION
This fixes the issue brought up in #1129 where a long output file type could overflow the buffer created in `parse_cmdline_encoder`.