### PR TITLE
Add -DBUILD_PKGCONFIG_FILES to install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,6 +30,7 @@ Main available cmake flags:
   * To specify the install path: '-DCMAKE\_INSTALL\_PREFIX=/path'
   * To build the shared libraries and links the executables against it: '-DBUILD\_SHARED\_LIBS:bool=on' (default: 'ON')
 > Note: when using this option, static libraries are not built and executables are dynamically linked.
+  * PKG_CONFIG files are by default built for Unix compile, you can force to build on other platforms by adding: '-DBUILD_PKGCONFIG_FILES=on'
   * To build the CODEC executables: '-DBUILD\_CODEC:bool=on' (default: 'ON')
   * To build opjstyle (internal version of astyle) for OpenJPEG development: '-DWITH_ASTYLE=ON'
   * [OBSOLETE] To build the MJ2 executables: '-DBUILD\_MJ2:bool=on' (default: 'OFF')


### PR DESCRIPTION
Building under msys/mingw doesn't automatically install the pkg config files needed to build GDAL and other libraries.