### PR TITLE
Relative path to header files is hardcoded in OpenJPEGConfig.cmake.in file

### DIFF
--- a/cmake/OpenJPEGConfig.cmake.in
+++ b/cmake/OpenJPEGConfig.cmake.in
@@ -26,8 +26,13 @@ get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 if(EXISTS ${SELF_DIR}/OpenJPEGTargets.cmake)
   # This is an install tree
   include(${SELF_DIR}/OpenJPEGTargets.cmake)
-  get_filename_component(OPENJPEG_INCLUDE_ROOT "${SELF_DIR}/../../@OPENJPEG_INSTALL_INCLUDE_DIR@" ABSOLUTE)
-  set(OPENJPEG_INCLUDE_DIRS ${OPENJPEG_INCLUDE_ROOT})
+
+  # We find a relative path from the PKG directory to header files.
+  set(PKG_DIR "@CMAKE_INSTALL_PREFIX@/@OPENJPEG_INSTALL_PACKAGE_DIR@")
+  set(INC_DIR "@CMAKE_INSTALL_PREFIX@/@OPENJPEG_INSTALL_INCLUDE_DIR@")
+  file(RELATIVE_PATH PKG_TO_INC_RPATH "${PKG_DIR}" "${INC_DIR}")
+
+  get_filename_component(OPENJPEG_INCLUDE_DIRS "${SELF_DIR}/${PKG_TO_INC_RPATH}" ABSOLUTE)
 
 else()
   if(EXISTS ${SELF_DIR}/OpenJPEGExports.cmake)


### PR DESCRIPTION
Hi,

Solaris usually installs cmake configure files to /usr/lib/cmake/<pkg>/ and /usr/lib/$(MACH64)/cmake/<pkg>/ directories, however, file OpenJPEGConfig.cmake.in assumes the fixed relative path that can be wrong if OPENJPEG_INSTALL_PACKAGE_DIR variable is manually changed.

The proposed change, tested on Solaris, Linux, and Windows, solves this problem by replacing the fixed relative path with the real one.