### PR TITLE
jp3d/jpwl convert: fix write stack buffer overflow

### DIFF
--- a/src/bin/jp2/convert.c
+++ b/src/bin/jp2/convert.c
@@ -2233,6 +2233,11 @@ int imagetopnm(opj_image_t * image, const char *outfile, int force_split)
                 opj_version(), wr, hr, max);
 
         red = image->comps[compno].data;
+        if (!red) {
+            fclose(fdest);
+            continue;
+        }
+
         adjustR =
             (image->comps[compno].sgnd ? 1 << (image->comps[compno].prec - 1) : 0);
 

--- a/src/bin/jp3d/convert.c
+++ b/src/bin/jp3d/convert.c
@@ -297,8 +297,8 @@ opj_volume_t* pgxtovolume(char *relpath, opj_cparameters_t *parameters)
         fprintf(stdout, "[INFO] Loading %s \n", pgxfiles[pos]);
 
         fseek(f, 0, SEEK_SET);
-        fscanf(f, "PG%[ \t]%c%c%[ \t+-]%d%[ \t]%d%[ \t]%d", temp, &endian1, &endian2,
-               signtmp, &prec, temp, &w, temp, &h);
+        fscanf(f, "PG%31[ \t]%c%c%31[ \t+-]%d%31[ \t]%d%31[ \t]%d", temp, &endian1,
+               &endian2, signtmp, &prec, temp, &w, temp, &h);
 
         i = 0;
         sign = '+';

--- a/src/bin/jpwl/convert.c
+++ b/src/bin/jpwl/convert.c
@@ -1349,7 +1349,7 @@ opj_image_t* pgxtoimage(const char *filename, opj_cparameters_t *parameters)
     }
 
     fseek(f, 0, SEEK_SET);
-    if (fscanf(f, "PG%[ \t]%c%c%[ \t+-]%d%[ \t]%d%[ \t]%d", temp, &endian1,
+    if (fscanf(f, "PG%31[ \t]%c%c%31[ \t+-]%d%31[ \t]%d%31[ \t]%d", temp, &endian1,
                &endian2, signtmp, &prec, temp, &w, temp, &h) != 9) {
         fprintf(stderr,
                 "ERROR: Failed to read the right number of element from the fscanf() function!\n");


### PR DESCRIPTION
Missing buffer length formatter in fscanf call might lead to write stack buffer overflow.

(same patch as  e5285319229a5d77bf316bb0d3a6cbd3cb8666d9)

Fixes #1044 (CVE-2017-17480).