### PR TITLE
openjp2/j2k: Report error if all wanted components are not decoded.

### DIFF
--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1571,17 +1571,6 @@ int main(int argc, char **argv)
             }
         }
 
-        /* FIXME? Shouldn't that situation be considered as an error of */
-        /* opj_decode() / opj_get_decoded_tile() ? */
-        if (image->comps[0].data == NULL) {
-            fprintf(stderr, "ERROR -> opj_decompress: no image data!\n");
-            opj_destroy_codec(l_codec);
-            opj_stream_destroy(l_stream);
-            opj_image_destroy(image);
-            failed = 1;
-            goto fin;
-        }
-
         tCumulative += opj_clock() - t;
         numDecompressedImages++;
 


### PR DESCRIPTION
Previously the caller had to check whether each component data had
been decoded. This means duplicating the checking in every user of
openjpeg which is unnecessary. If the caller wantes to decode all
or a set of, or a specific component then openjpeg ought to error
out if it was unable to do so.

Fixes #1158.
