### PR TITLE
CMakeLists.txt: remove some evil codes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,9 +176,6 @@ configure_file(
 # OpenJPEG build configuration options.
 option(BUILD_SHARED_LIBS "Build OpenJPEG shared library and link executables against it." ON)
 option(BUILD_STATIC_LIBS "Build OpenJPEG static library." ON)
-set (EXECUTABLE_OUTPUT_PATH ${OPENJPEG_BINARY_DIR}/bin CACHE PATH "Single output directory for building all executables.")
-set (LIBRARY_OUTPUT_PATH ${OPENJPEG_BINARY_DIR}/bin CACHE PATH "Single output directory for building all libraries.")
-mark_as_advanced(LIBRARY_OUTPUT_PATH EXECUTABLE_OUTPUT_PATH)
 
 #-----------------------------------------------------------------------------
 # configure name mangling to allow multiple libraries to coexist


### PR DESCRIPTION
when building as sub directory in project, these evil codes will change other project target's output