### PR TITLE
Extract RSIZ marker on decoding

### DIFF
--- a/src/lib/openjp2/image.c
+++ b/src/lib/openjp2/image.c
@@ -171,6 +171,8 @@ void opj_copy_image_header(const opj_image_t* p_image_src,
     assert(p_image_src != 00);
     assert(p_image_dest != 00);
 
+    p_image_dest->rsiz = p_image_src->rsiz;
+
     p_image_dest->x0 = p_image_src->x0;
     p_image_dest->y0 = p_image_src->y0;
     p_image_dest->x1 = p_image_src->x1;

--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -2072,6 +2072,8 @@ static OPJ_BOOL opj_j2k_read_siz(opj_j2k_t *p_j2k,
                    2);                                                /* Rsiz (capabilities) */
     p_header_data += 2;
     l_cp->rsiz = (OPJ_UINT16) l_tmp;
+    l_image->rsiz = l_cp->rsiz;
+
     opj_read_bytes(p_header_data, (OPJ_UINT32*) &l_image->x1, 4);   /* Xsiz */
     p_header_data += 4;
     opj_read_bytes(p_header_data, (OPJ_UINT32*) &l_image->y1, 4);   /* Ysiz */

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -667,6 +667,8 @@ typedef struct opj_image_comp {
  * Defines image data and characteristics
  * */
 typedef struct opj_image {
+    /** RSIZ: capabilities */
+    OPJ_UINT16 rsiz;
     /** XOsiz: horizontal offset from the origin of the reference grid to the left side of the image area */
     OPJ_UINT32 x0;
     /** YOsiz: vertical offset from the origin of the reference grid to the top side of the image area */

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -667,8 +667,6 @@ typedef struct opj_image_comp {
  * Defines image data and characteristics
  * */
 typedef struct opj_image {
-    /** RSIZ: capabilities */
-    OPJ_UINT16 rsiz;
     /** XOsiz: horizontal offset from the origin of the reference grid to the left side of the image area */
     OPJ_UINT32 x0;
     /** YOsiz: vertical offset from the origin of the reference grid to the top side of the image area */
@@ -687,6 +685,8 @@ typedef struct opj_image {
     OPJ_BYTE *icc_profile_buf;
     /** size of ICC profile */
     OPJ_UINT32 icc_profile_len;
+    /** RSIZ: capabilities */
+    OPJ_UINT16 rsiz;
 } opj_image_t;
 
 


### PR DESCRIPTION
This PR address the issue described in #1198.