### PR TITLE
ICC data in color_apply_icc_profile() collide with number of CDEF channels

### DIFF
--- a/src/bin/common/color.c
+++ b/src/bin/common/color.c
@@ -462,6 +462,7 @@ void color_apply_icc_profile(opj_image_t *image)
     cmsUInt32Number intent, in_type, out_type;
     int *r, *g, *b;
     size_t nr_samples, i, max, max_w, max_h;
+    unsigned int nr_comp = 0;
     int prec, ok = 0;
     OPJ_COLOR_SPACE new_space;
 
@@ -485,8 +486,15 @@ void color_apply_icc_profile(opj_image_t *image)
     max_h = image->comps[0].h;
     prec = (int)image->comps[0].prec;
 
+    nr_comp = image->numcomps;
+
     if (out_space == cmsSigRgbData) { /* enumCS 16 */
-        unsigned int i, nr_comp = image->numcomps;
+        unsigned int i;
+
+        if (nr_comp < 3) { /* GRAY or GRAYA, not RGB or RGBA */
+            cmsCloseProfile(in_prof);
+            return;
+        }
 
         if (nr_comp > 4) {
             nr_comp = 4;
@@ -529,6 +537,12 @@ void color_apply_icc_profile(opj_image_t *image)
         out_prof = cmsCreate_sRGBProfile();
         new_space = OPJ_CLRSPC_SRGB;
     } else if (out_space == cmsSigYCbCrData) { /* enumCS 18 */
+
+        if (nr_comp < 3) {
+            cmsCloseProfile(in_prof);
+            return;
+        }
+
         in_type = TYPE_YCbCr_16;
         out_type = TYPE_RGB_16;
         out_prof = cmsCreate_sRGBProfile();


### PR DESCRIPTION
See issue #1207: files 0001.jp2, 0003.jp2 and 0004.jp2 have 1 component
(GRAY) but their ICC data need > 2 components.