### PR TITLE
Small changes to j2k.c and t2.c that enable decoding of truncated jp2 files

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -4695,7 +4695,7 @@ static OPJ_BOOL opj_j2k_read_sod(opj_j2k_t *p_j2k,
     opj_tcp_t * l_tcp = 00;
     OPJ_UINT32 * l_tile_len = 00;
     OPJ_BOOL l_sot_length_pb_detected = OPJ_FALSE;
-
+    int truncate = 0;
     /* preconditions */
     assert(p_j2k != 00);
     assert(p_manager != 00);
@@ -4728,9 +4728,10 @@ static OPJ_BOOL opj_j2k_read_sod(opj_j2k_t *p_j2k,
         /* Check enough bytes left in stream before allocation */
         if ((OPJ_OFF_T)p_j2k->m_specific_param.m_decoder.m_sot_length >
                 opj_stream_get_number_byte_left(p_stream)) {
-            opj_event_msg(p_manager, EVT_ERROR,
-                          "Tile part length size inconsistent with stream length\n");
-            return OPJ_FALSE;
+            truncate = 1
+           //  opj_event_msg(p_manager, EVT_ERROR,
+           //               "Tile part length size inconsistent with stream length\n");
+           // return OPJ_FALSE;
         }
         if (p_j2k->m_specific_param.m_decoder.m_sot_length >
                 UINT_MAX - OPJ_COMMON_CBLK_DATA_EXTRA) {
@@ -4804,7 +4805,7 @@ static OPJ_BOOL opj_j2k_read_sod(opj_j2k_t *p_j2k,
 
         /*l_cstr_index->packno = 0;*/
     }
-
+    
     /* Patch to support new PHR data */
     if (!l_sot_length_pb_detected) {
         l_current_read_size = opj_stream_read_data(
@@ -4816,7 +4817,7 @@ static OPJ_BOOL opj_j2k_read_sod(opj_j2k_t *p_j2k,
         l_current_read_size = 0;
     }
 
-    if (l_current_read_size != p_j2k->m_specific_param.m_decoder.m_sot_length) {
+    if ((l_current_read_size != p_j2k->m_specific_param.m_decoder.m_sot_length) || (truncate > 0) ) {
         p_j2k->m_specific_param.m_decoder.m_state = J2K_STATE_NEOC;
     } else {
         p_j2k->m_specific_param.m_decoder.m_state = J2K_STATE_TPHSOT;

--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -4728,7 +4728,7 @@ static OPJ_BOOL opj_j2k_read_sod(opj_j2k_t *p_j2k,
         /* Check enough bytes left in stream before allocation */
         if ((OPJ_OFF_T)p_j2k->m_specific_param.m_decoder.m_sot_length >
                 opj_stream_get_number_byte_left(p_stream)) {
-            truncate = 1
+            truncate = 1;
            //  opj_event_msg(p_manager, EVT_ERROR,
            //               "Tile part length size inconsistent with stream length\n");
            // return OPJ_FALSE;

--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -4747,8 +4747,15 @@ static OPJ_BOOL opj_j2k_read_sod(opj_j2k_t *p_j2k,
             /* LH: oddly enough, in this path, l_tile_len!=0.
              * TODO: If this was consistent, we could simplify the code to only use realloc(), as realloc(0,...) default to malloc(0,...).
              */
-            *l_current_data = (OPJ_BYTE*) opj_malloc(
-                                  p_j2k->m_specific_param.m_decoder.m_sot_length + OPJ_COMMON_CBLK_DATA_EXTRA);
+            if (!truncate)
+            {
+                    *l_current_data = (OPJ_BYTE*) opj_malloc(
+                                          p_j2k->m_specific_param.m_decoder.m_sot_length + OPJ_COMMON_CBLK_DATA_EXTRA);
+            }
+            else
+            {
+                *l_current_data = (OPJ_BYTE*) opj_malloc(opj_stream_get_number_byte_left(p_stream) + OPJ_COMMON_CBLK_DATA_EXTRA);
+            }
         } else {
             OPJ_BYTE *l_new_current_data;
             if (*l_tile_len > UINT_MAX - OPJ_COMMON_CBLK_DATA_EXTRA -
@@ -4758,10 +4765,18 @@ static OPJ_BOOL opj_j2k_read_sod(opj_j2k_t *p_j2k,
                               "p_j2k->m_specific_param.m_decoder.m_sot_length");
                 return OPJ_FALSE;
             }
-
+            if (!truncate)
+            {
             l_new_current_data = (OPJ_BYTE *) opj_realloc(*l_current_data,
                                  *l_tile_len + p_j2k->m_specific_param.m_decoder.m_sot_length +
                                  OPJ_COMMON_CBLK_DATA_EXTRA);
+            }
+            else
+            {
+            l_new_current_data = (OPJ_BYTE *) opj_realloc(*l_current_data,
+                                 *l_tile_len + opj_stream_get_number_byte_left(p_stream) +
+                                 OPJ_COMMON_CBLK_DATA_EXTRA);
+            }
             if (! l_new_current_data) {
                 opj_free(*l_current_data);
                 /*nothing more is done as l_current_data will be set to null, and just

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1313,6 +1313,7 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
 
     OPJ_ARG_NOT_USED(p_t2);
     OPJ_ARG_NOT_USED(pack_info);
+    int truncate = 0;
 
     l_band = l_res->bands;
     for (bandno = 0; bandno < l_res->numbands; ++bandno) {
@@ -1346,7 +1347,7 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
                     ++l_cblk->numsegs;
                 }
             }
-            int truncate = 0;
+            truncate = 0;
             do {
                 /* Check possible overflow (on l_current_data only, assumes input args already checked) then size */
                if ((((OPJ_SIZE_T)l_current_data + (OPJ_SIZE_T)l_seg->newlen) <
@@ -1358,7 +1359,7 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
                                  l_seg->newlen, l_current_data, p_src_data, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
                                  p_pi->compno);                   
                    truncate = 1;
-                   l_seg->newlen =p_src_data + p_max_length - l_current_data;
+                   l_seg->newlen = p_src_data + p_max_length - l_current_data;
                  
                    //opj_event_msg(p_manager, EVT_ERROR,
                    //              "read: segment too long (%d) current data (%d) p_src_data (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1355,10 +1355,10 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
                        (OPJ_SIZE_T)l_current_data) ||
                        (l_current_data + l_seg->newlen > p_src_data + p_max_length)) {
                  
-                   opj_event_msg(p_manager, EVT_WARNING,
-                                 "read: segment too long (%d) current data (%d) p_src_data (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
-                                 l_seg->newlen, l_current_data, p_src_data, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
-                                 p_pi->compno);                   
+                   //opj_event_msg(p_manager, EVT_WARNING,
+                   //              "read: segment too long (%d) current data (%d) p_src_data (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
+                   //              l_seg->newlen, l_current_data, p_src_data, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
+                   //              p_pi->compno);                   
                    truncate = 1;
                    l_seg->newlen = (OPJ_SIZE_T)(p_src_data + p_max_length - l_current_data);
                  

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1497,7 +1497,7 @@ static OPJ_BOOL opj_t2_skip_packet_data(opj_t2_t* p_t2,
                     //              l_seg->newlen, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
                     //              p_pi->compno);
                     truncate = 1;
-                    l_seg->newlen = (OPJ_SIZE_T)(p_max_length - p_src_data);
+                    l_seg->newlen = (OPJ_SIZE_T)(p_max_length - p_data_read);
                   
                     return OPJ_FALSE;
                 }

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1499,7 +1499,7 @@ static OPJ_BOOL opj_t2_skip_packet_data(opj_t2_t* p_t2,
                     truncate = 1;
                     l_seg->newlen = (OPJ_SIZE_T)(p_max_length - *p_data_read);
                   
-                    return OPJ_FALSE;
+                    // return OPJ_FALSE;
                 }
 
 #ifdef USE_JPWL

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1349,15 +1349,15 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
 
             do {
                 /* Check possible overflow (on l_current_data only, assumes input args already checked) then size */
-                if ((((OPJ_SIZE_T)l_current_data + (OPJ_SIZE_T)l_seg->newlen) <
-                        (OPJ_SIZE_T)l_current_data) ||
-                        (l_current_data + l_seg->newlen > p_src_data + p_max_length)) {
-                    opj_event_msg(p_manager, EVT_ERROR,
-                                  "read: segment too long (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
-                                  l_seg->newlen, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
-                                  p_pi->compno);
-                    return OPJ_FALSE;
-                }
+               //if ((((OPJ_SIZE_T)l_current_data + (OPJ_SIZE_T)l_seg->newlen) <
+               //        (OPJ_SIZE_T)l_current_data) ||
+               //        (l_current_data + l_seg->newlen > p_src_data + p_max_length)) {
+               //    opj_event_msg(p_manager, EVT_ERROR,
+               //                  "read: segment too long (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
+               //                  l_seg->newlen, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
+               //                  p_pi->compno);
+               //    return OPJ_FALSE;
+               //}
 
 #ifdef USE_JPWL
                 /* we need here a j2k handle to verify if making a check to

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1346,7 +1346,7 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
                     ++l_cblk->numsegs;
                 }
             }
-
+            int truncate = 0
             do {
                 /* Check possible overflow (on l_current_data only, assumes input args already checked) then size */
                if ((((OPJ_SIZE_T)l_current_data + (OPJ_SIZE_T)l_seg->newlen) <
@@ -1356,9 +1356,9 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
                    opj_event_msg(p_manager, EVT_WARNING,
                                  "read: segment too long (%d) current data (%d) p_src_data (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
                                  l_seg->newlen, l_current_data, p_src_data, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
-                                 p_pi->compno);
-                   break;
-                 
+                                 p_pi->compno);                   
+                   truncate = 1;
+                   l_seg->newlen =p_src_data + p_max_length - l_current_data
                  
                    //opj_event_msg(p_manager, EVT_ERROR,
                    //              "read: segment too long (%d) current data (%d) p_src_data (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
@@ -1417,7 +1417,7 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
                     ++l_seg;
                     ++l_cblk->numsegs;
                 }
-            } while (l_cblk->numnewpasses > 0);
+            } while (l_cblk->numnewpasses > 0 && !truncate);
 
             l_cblk->real_num_segs = l_cblk->numsegs;
             ++l_cblk;

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1349,15 +1349,15 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
 
             do {
                 /* Check possible overflow (on l_current_data only, assumes input args already checked) then size */
-               //if ((((OPJ_SIZE_T)l_current_data + (OPJ_SIZE_T)l_seg->newlen) <
-               //        (OPJ_SIZE_T)l_current_data) ||
-               //        (l_current_data + l_seg->newlen > p_src_data + p_max_length)) {
-               //    opj_event_msg(p_manager, EVT_ERROR,
-               //                  "read: segment too long (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
-               //                  l_seg->newlen, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
-               //                  p_pi->compno);
-               //    return OPJ_FALSE;
-               //}
+               if ((((OPJ_SIZE_T)l_current_data + (OPJ_SIZE_T)l_seg->newlen) <
+                       (OPJ_SIZE_T)l_current_data) ||
+                       (l_current_data + l_seg->newlen > p_src_data + p_max_length)) {
+                   opj_event_msg(p_manager, EVT_ERROR,
+                                 "read: segment too long (%d) current data (%d) p_src_data (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
+                                 l_seg->newlen, l_current_data, p_src_data, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
+                                 p_pi->compno);
+                   return OPJ_FALSE;
+               }
 
 #ifdef USE_JPWL
                 /* we need here a j2k handle to verify if making a check to

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1444,6 +1444,7 @@ static OPJ_BOOL opj_t2_skip_packet_data(opj_t2_t* p_t2,
 {
     OPJ_UINT32 bandno, cblkno;
     OPJ_UINT32 l_nb_code_blocks;
+    int truncate;
     opj_tcd_band_t *l_band = 00;
     opj_tcd_cblk_dec_t* l_cblk = 00;
     opj_tcd_resolution_t* l_res =
@@ -1486,15 +1487,18 @@ static OPJ_BOOL opj_t2_skip_packet_data(opj_t2_t* p_t2,
                     ++l_cblk->numsegs;
                 }
             }
-
+            truncate = 0;
             do {
                 /* Check possible overflow then size */
                 if (((*p_data_read + l_seg->newlen) < (*p_data_read)) ||
                         ((*p_data_read + l_seg->newlen) > p_max_length)) {
-                    opj_event_msg(p_manager, EVT_ERROR,
-                                  "skip: segment too long (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
-                                  l_seg->newlen, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
-                                  p_pi->compno);
+                    //opj_event_msg(p_manager, EVT_ERROR,
+                    //              "skip: segment too long (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
+                    //              l_seg->newlen, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
+                    //              p_pi->compno);
+                    truncate = 1;
+                    l_seg->newlen = (OPJ_SIZE_T)(p_src_data + p_max_length - l_current_data);
+                  
                     return OPJ_FALSE;
                 }
 
@@ -1528,7 +1532,7 @@ static OPJ_BOOL opj_t2_skip_packet_data(opj_t2_t* p_t2,
                     ++l_seg;
                     ++l_cblk->numsegs;
                 }
-            } while (l_cblk->numnewpasses > 0);
+            } while (l_cblk->numnewpasses > 0  && !truncate);
 
             ++l_cblk;
         }

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1305,6 +1305,7 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
 {
     OPJ_UINT32 bandno, cblkno;
     OPJ_UINT32 l_nb_code_blocks;
+    int truncate;
     OPJ_BYTE *l_current_data = p_src_data;
     opj_tcd_band_t *l_band = 00;
     opj_tcd_cblk_dec_t* l_cblk = 00;
@@ -1313,7 +1314,7 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
 
     OPJ_ARG_NOT_USED(p_t2);
     OPJ_ARG_NOT_USED(pack_info);
-    int truncate = 0;
+    
 
     l_band = l_res->bands;
     for (bandno = 0; bandno < l_res->numbands; ++bandno) {
@@ -1359,7 +1360,7 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
                                  l_seg->newlen, l_current_data, p_src_data, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
                                  p_pi->compno);                   
                    truncate = 1;
-                   l_seg->newlen = p_src_data + p_max_length - l_current_data;
+                   l_seg->newlen = (OPJ_SIZE_T)(p_src_data + p_max_length - l_current_data);
                  
                    //opj_event_msg(p_manager, EVT_ERROR,
                    //              "read: segment too long (%d) current data (%d) p_src_data (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1497,7 +1497,7 @@ static OPJ_BOOL opj_t2_skip_packet_data(opj_t2_t* p_t2,
                     //              l_seg->newlen, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
                     //              p_pi->compno);
                     truncate = 1;
-                    l_seg->newlen = (OPJ_SIZE_T)(p_max_length - p_data_read);
+                    l_seg->newlen = (OPJ_SIZE_T)(p_max_length - *p_data_read);
                   
                     return OPJ_FALSE;
                 }

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1352,11 +1352,19 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
                if ((((OPJ_SIZE_T)l_current_data + (OPJ_SIZE_T)l_seg->newlen) <
                        (OPJ_SIZE_T)l_current_data) ||
                        (l_current_data + l_seg->newlen > p_src_data + p_max_length)) {
-                   opj_event_msg(p_manager, EVT_ERROR,
+                 
+                   opj_event_msg(p_manager, EVT_WARNING,
                                  "read: segment too long (%d) current data (%d) p_src_data (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
                                  l_seg->newlen, l_current_data, p_src_data, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
                                  p_pi->compno);
-                   return OPJ_FALSE;
+                   break;
+                 
+                 
+                   //opj_event_msg(p_manager, EVT_ERROR,
+                   //              "read: segment too long (%d) current data (%d) p_src_data (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",
+                   //              l_seg->newlen, l_current_data, p_src_data, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
+                   //              p_pi->compno);
+                   //return OPJ_FALSE;
                }
 
 #ifdef USE_JPWL

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1497,7 +1497,7 @@ static OPJ_BOOL opj_t2_skip_packet_data(opj_t2_t* p_t2,
                     //              l_seg->newlen, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
                     //              p_pi->compno);
                     truncate = 1;
-                    l_seg->newlen = (OPJ_SIZE_T)(p_src_data + p_max_length - l_current_data);
+                    l_seg->newlen = (OPJ_SIZE_T)(p_max_length - p_src_data);
                   
                     return OPJ_FALSE;
                 }

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1346,7 +1346,7 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
                     ++l_cblk->numsegs;
                 }
             }
-            int truncate = 0
+            int truncate = 0;
             do {
                 /* Check possible overflow (on l_current_data only, assumes input args already checked) then size */
                if ((((OPJ_SIZE_T)l_current_data + (OPJ_SIZE_T)l_seg->newlen) <
@@ -1358,7 +1358,7 @@ static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
                                  l_seg->newlen, l_current_data, p_src_data, p_max_length, cblkno, p_pi->precno, bandno, p_pi->resno,
                                  p_pi->compno);                   
                    truncate = 1;
-                   l_seg->newlen =p_src_data + p_max_length - l_current_data
+                   l_seg->newlen =p_src_data + p_max_length - l_current_data;
                  
                    //opj_event_msg(p_manager, EVT_ERROR,
                    //              "read: segment too long (%d) current data (%d) p_src_data (%d) with max (%d) for codeblock %d (p=%d, b=%d, r=%d, c=%d)\n",


### PR DESCRIPTION
Fixes #715
OpenJPEG 1.5.0 used to be able to open truncated jp2 files.
OpenJPEG 2 now gives errors. 

These changes enable the reading of incomplete jp2 files. 

