### PR TITLE
tests/fuzzers: link fuzz binaries using $LIB_FUZZING_ENGINE.

### DIFF
--- a/tests/fuzzers/GNUmakefile
+++ b/tests/fuzzers/GNUmakefile
@@ -8,5 +8,6 @@ fuzzingengine.o: fuzzingengine.c
 
 dummyfuzzers: fuzzingengine.o
 	$(AR) r libFuzzingEngine.a fuzzingengine.o
-	CXX="${CXX}" CXXFLAGS="-L. ${CXXFLAGS}" SRC=/tmp OUT=/tmp ./build_google_oss_fuzzers.sh
+	LIB_FUZZING_ENGINE="-lFuzzingEngine" CXX="${CXX}" CXXFLAGS="-L. ${CXXFLAGS}" \
+	    SRC=/tmp OUT=/tmp ./build_google_oss_fuzzers.sh
 	OUT=/tmp ./build_seed_corpus.sh

--- a/tests/fuzzers/build_google_oss_fuzzers.sh
+++ b/tests/fuzzers/build_google_oss_fuzzers.sh
@@ -28,7 +28,7 @@ build_fuzzer()
     echo "Building fuzzer $fuzzerName"
     $CXX $CXXFLAGS -std=c++11 -I$SRC_DIR/src/lib/openjp2 -I$SRC_DIR/build/src/lib/openjp2 \
         $sourceFilename $* -o $OUT/$fuzzerName \
-        -lFuzzingEngine $SRC_DIR/build/bin/libopenjp2.a -lm -lpthread
+        $LIB_FUZZING_ENGINE $SRC_DIR/build/bin/libopenjp2.a -lm -lpthread
 }
 
 fuzzerFiles=$(dirname $0)/*.cpp


### PR DESCRIPTION
This was changed some time ago (https://google.github.io/oss-fuzz/getting-started/new-project-guide/) but the build didn't fail as there is a fallback mechanism. The main advantage of the new approach is that for libFuzzer this produces more performant binaries (as `$LIB_FUZZING_ENGINE` expands into `-fsanitize=fuzzer`, which links libFuzzer from the compiler-rt, allowing better optimization tricks).

I'm also experimenting with dataflow (https://github.com/google/oss-fuzz/issues/1632) on your project, and the dataflow config doesn't have a fallback (as it's a new configuration), therefore I'm proposing a change to migrate from `-lFuzzingEngine` to `$LIB_FUZZING_ENGINE`.