### PR TITLE
tests: add alternate checksums for libtiff 4.1

### DIFF
--- a/tests/nonregression/checkmd5refs.cmake
+++ b/tests/nonregression/checkmd5refs.cmake
@@ -46,10 +46,15 @@ foreach(pgxfullpath ${globfiles})
 
   string(REGEX MATCH "[0-9a-f]+  ${pgxfile}" output_var "${variable}")
 
+  # Search for variant md5sum for libtiff >= 4.1
+  string(REGEX MATCH "libtiff_4_1:[0-9a-f]+  ${pgxfile}" alternate_output_var "${variable}")
+
   set(output "${output}  ${pgxfile}")
 
   if("${output_var}" STREQUAL "${output}")
     message(STATUS "equal: [${output_var}] vs [${output}]")
+  elseif("${alternate_output_var}" STREQUAL "libtiff_4_1:${output}")
+    message(STATUS "equal: [${alternate_output_var}] vs [libtiff_4_1:${output}]")
   else()
     message(SEND_ERROR "not equal: [${output_var}] vs [${output}]")
   endif()

--- a/tests/nonregression/md5refs.txt
+++ b/tests/nonregression/md5refs.txt
@@ -180,6 +180,7 @@ dacaf60e4c430916a8c2a9ebec32e71c  issue458.jp2_3.pgx
 d33fb5dbddb9b9b4438eb51fa27445a3  issue495.jp2_0.pgx
 27db8c35e12a5d5eb94d403d2aae2909  issue495.jp2_1.pgx
 97da625d2f2d0b75bf891d8083ce8bfb  issue495.jp2_2.pgx
+
 86729c5f2b74b2dfd42cb0d8e47aef79  a1_mono_tif-1.tif
 fa9b7b896536b25a7a1d8eeeacb59141  a1_mono_tif-10.tif
 e1f194f69d1c58ce8bed62cd4f1d5b6a  a1_mono_tif-11.tif
@@ -196,6 +197,24 @@ de53251a33356e206a793fbdbaf90db2  a1_mono_tif-13.tif
 e164a6c0219737ee05a3d55d6e3a3104  a1_mono_tif-7.tif
 c3ebfcf478b1c4fc786748813f2b5d53  a1_mono_tif-8.tif
 67adb084f1fe234f240a1d0b2698507e  a1_mono_tif-9.tif
+
+libtiff_4_1:fc19057ff2d65c24daf9c9e25e34a48a  a1_mono_tif-1.tif
+libtiff_4_1:66246b6bbc83c06962f034235acb9924  a1_mono_tif-10.tif
+libtiff_4_1:ce1e07bdafe83a84a5df87fce2ffde6a  a1_mono_tif-11.tif
+libtiff_4_1:614f1ab59ca8473f5f8b1772b7a19d24  a1_mono_tif-12.tif
+libtiff_4_1:941bdcdf9103a22f7b6f66aaca3276d1  a1_mono_tif-13.tif
+libtiff_4_1:38df45296861df2b44879e8a0787d43c  a1_mono_tif-14.tif
+libtiff_4_1:387575ff38bed3d177776891e1b2804e  a1_mono_tif-15.tif
+libtiff_4_1:ee4838fbd88ddcb73ef26df523a3bb5d  a1_mono_tif-16.tif
+libtiff_4_1:6de7e8cbd95e2c465b587f2273daf9dc  a1_mono_tif-2.tif
+libtiff_4_1:e1e026d7ed26e8f3334cf25a8884abbd  a1_mono_tif-3.tif
+libtiff_4_1:c120fac03d1b3756a2deb9b92ba519d4  a1_mono_tif-4.tif
+libtiff_4_1:3a7b84ed9061e0b13996660fc2910e8a  a1_mono_tif-5.tif
+libtiff_4_1:7ac8316261d54f22e6c847fbac01542b  a1_mono_tif-6.tif
+libtiff_4_1:d714670f6746931c4e7defbfbe38b249  a1_mono_tif-7.tif
+libtiff_4_1:b28f4b92be5e3481d44f50f2cd7626aa  a1_mono_tif-8.tif
+libtiff_4_1:2a12dcda3e9927384e7344c4ecabdcf1  a1_mono_tif-9.tif
+
 31650ec40241737634179fff6ad306f8  basn4a08_tif-1.tif
 abf884080bcfbf58c044a9d86bfa5e5d  basn4a08_tif-10.tif
 b0d82c12aa2c9b3ecd96c6a5b5663a8c  basn4a08_tif-11.tif
@@ -212,6 +231,24 @@ fb5cf848d63c61dc485c87c9246ee9c7  basn4a08_tif-16.tif
 18a59ac6036ee64e92af19b7e3cd3d64  basn4a08_tif-7.tif
 dc40cc1da6de28e7e973c8ba796ca189  basn4a08_tif-8.tif
 824b776a5aa3459b77894b5f77621311  basn4a08_tif-9.tif
+
+libtiff_4_1:4c50df5b25e006041b05e8a6fb77c95e  basn4a08_tif-1.tif
+libtiff_4_1:68cc9a9bc5f95474744d06ea4efb2cf3  basn4a08_tif-10.tif
+libtiff_4_1:f643c00bd0673c8f6092125e38759a35  basn4a08_tif-11.tif
+libtiff_4_1:cfcefece2fb08a437876d85941cdaa27  basn4a08_tif-12.tif
+libtiff_4_1:1c3850831691aa8b565e4cd0d13166f9  basn4a08_tif-13.tif
+libtiff_4_1:06059e0429956946ecd3b1893ad39d18  basn4a08_tif-14.tif
+libtiff_4_1:71557ba6728e6641ad289b1d142acade  basn4a08_tif-15.tif
+libtiff_4_1:150c663277b43d0331112f24d47fd34e  basn4a08_tif-16.tif
+libtiff_4_1:9b43011e7a19079c21d65318b4a1139b  basn4a08_tif-2.tif
+libtiff_4_1:125ca7b2e45fafa4e003f5adc9f11da8  basn4a08_tif-3.tif
+libtiff_4_1:9fbc1a8f4d12c8152cde3e004cebd191  basn4a08_tif-4.tif
+libtiff_4_1:51c6b54e9d8b53355c3f73ad813bdeef  basn4a08_tif-5.tif
+libtiff_4_1:604ac42b1a9e7a75d63e97ce40e43442  basn4a08_tif-6.tif
+libtiff_4_1:360d1ce74faffa1a736d5f30c22976ed  basn4a08_tif-7.tif
+libtiff_4_1:2059aaa9e54c09f36d16107870c1546a  basn4a08_tif-8.tif
+libtiff_4_1:07496859507882401d66d70dcf392505  basn4a08_tif-9.tif
+
 59e32c45591fd3bb44fe99381a116ba1  basn6a08_tif-1.tif
 630e6fb6deba0b3efd93b610561d607a  basn6a08_tif-10.tif
 5419fec92f0e0e5907d838dacf9712b4  basn6a08_tif-11.tif
@@ -228,6 +265,24 @@ d60864a6a5c8a49a202d98ae6f5165c7  basn6a08_tif-6.tif
 086fd12fec963995fe2e405dcef7e477  basn6a08_tif-7.tif
 c3e93f61125f82a9832d0b9440468034  basn6a08_tif-8.tif
 a9723dcc0732e74c9e8cd2bf93474a7d  basn6a08_tif-9.tif
+
+libtiff_4_1:98f777ca80a132d8ab820d4533daa5b6  basn6a08_tif-1.tif
+libtiff_4_1:9c5873a1fa5571aad9e73d36d5a4206a  basn6a08_tif-10.tif
+libtiff_4_1:c05dac7d4c19bc4b78cea426e5e52430  basn6a08_tif-11.tif
+libtiff_4_1:0223432f61df2508d0195f696988ddeb  basn6a08_tif-12.tif
+libtiff_4_1:ccc64d14279063ed9daf371be62077f7  basn6a08_tif-13.tif
+libtiff_4_1:ace0bab2c2fbb5f92a8214600df9159f  basn6a08_tif-14.tif
+libtiff_4_1:9b54bda92a09bcac9870fa02b428b7e6  basn6a08_tif-15.tif
+libtiff_4_1:178665d070f54f2920521c4e1cb9d5d0  basn6a08_tif-16.tif
+libtiff_4_1:c4b1e96d19429137cd8871833af2ea5a  basn6a08_tif-2.tif
+libtiff_4_1:44e8b5591740289d0ca52a3e19f19c22  basn6a08_tif-3.tif
+libtiff_4_1:70b4f469dd29c8e99d3f0525301286b8  basn6a08_tif-4.tif
+libtiff_4_1:bf7c35a2b05eecb406aab7959431a842  basn6a08_tif-5.tif
+libtiff_4_1:7d2ecb1c35869ddbafd11b4896357b81  basn6a08_tif-6.tif
+libtiff_4_1:2cd6ec32a0256806f46706c0ca564d9d  basn6a08_tif-7.tif
+libtiff_4_1:116b611b7a358bee2c4f2695732ec357  basn6a08_tif-8.tif
+libtiff_4_1:ed9ca54d25fb5b0cd5339eedfa16cbea  basn6a08_tif-9.tif
+
 cfe04d15cf9d615fc36357dcb3b3956b  p0_14_tif-1.tif
 9ad87e7fddc77ac85e2e92509bee2365  p0_14_tif-10.tif
 f144e26d6d5aa24d98f0415f10751025  p0_14_tif-11.tif
@@ -244,6 +299,24 @@ b6f71c941e3a5b8d2547792ccec58d54  p0_14_tif-4.tif
 951c99efbd922d8f3feb015e9ef8e350  p0_14_tif-7.tif
 6808377b760b4ef3559ba8b14ed9b91a  p0_14_tif-8.tif
 96aa7dafa873d0ce33f84bb1ff78fa9b  p0_14_tif-9.tif
+
+libtiff_4_1:5f97d4bbab138f99b6b125e5a5bf96bd  p0_14_tif-1.tif
+libtiff_4_1:686c7a1561d73e53c000800ec0c5fa0a  p0_14_tif-10.tif
+libtiff_4_1:a8585d901cc1b7cbbda6e524ecb5db35  p0_14_tif-11.tif
+libtiff_4_1:17b5497c9b8a0c68739c0beae90aa432  p0_14_tif-12.tif
+libtiff_4_1:a024a04b96ccb13c81cd57a5ee6ad07a  p0_14_tif-13.tif
+libtiff_4_1:aabadca3f87437a32878fef7e265b23a  p0_14_tif-14.tif
+libtiff_4_1:5390a77296962268b73a793467092633  p0_14_tif-15.tif
+libtiff_4_1:47dc7cc71832e5739c32794a713966c3  p0_14_tif-16.tif
+libtiff_4_1:1a9247cd1fb26f5fffa870e8543f6d30  p0_14_tif-2.tif
+libtiff_4_1:e4c0c9481d4032ea6b7e6a08a39e9030  p0_14_tif-3.tif
+libtiff_4_1:c7d6ec9b235aaff146228875e69edbaa  p0_14_tif-4.tif
+libtiff_4_1:d3b8110b2284a09cfb7d5c4ffd451aff  p0_14_tif-5.tif
+libtiff_4_1:6189ee17c4a276f99302ac7e296b3daa  p0_14_tif-6.tif
+libtiff_4_1:b4a3b9b63681448abb7c460702de4df9  p0_14_tif-7.tif
+libtiff_4_1:04deb4e9679e7971c2cd0449fcd255b7  p0_14_tif-8.tif
+libtiff_4_1:254443e438ed6a5b0631d6188cc84789  p0_14_tif-9.tif
+
 dd15b3d487d36a3682be0679300a4319  issue235.jp2_0.pgx
 b9cd6dc76b141fb1fec15f50c1f70e01  issue235.jp2_1.pgx
 3edef2ae197ef30b08deda1b28825399  issue235.jp2_2.pgx
@@ -288,6 +361,7 @@ fc2844a9f3c8e924e349180ba9e122dd  p0_14_png-2.png
 8d7685f1569d446787476c0a56c93750  dwt_interleave_h.gsr105.jp2_1.pgx
 ddfff2ce2df4a9102518c92a362e6d25  dwt_interleave_h.gsr105.jp2_2.pgx
 63bf755af5a1f8a478d65079dc7c8964  issue205-tif.jp2.tif
+libtiff_4_1:f9678a9e12d540f768ebebaee2af8f14  issue205-tif.jp2.tif
 b01ed87dbac424bc820b2ac590e4884e  issue236-ESYCC-CDEF.jp2_0.pgx
 2635cc00b1e18ef11adcba09e845d459  issue236-ESYCC-CDEF.jp2_1.pgx
 f9c95d0aec2f6e7b814fa1d09edcdbda  issue236-ESYCC-CDEF.jp2_2.pgx
@@ -310,11 +384,11 @@ d1bb7f93f4c0eb984b2e9c54e544b7e9  broken.jpc_1.pgx
 b704ad4c0cfefffd78c20a54f5541265  dwt_interleave_h.gsr105.jp2_d_1_1_33_33_0.pgx
 9d7fe43cd7a50b7bbaf712926ee11980  dwt_interleave_h.gsr105.jp2_d_1_1_33_33_1.pgx
 0960b580f991ff10f693b24aa41ad58b  dwt_interleave_h.gsr105.jp2_d_1_1_33_33_2.pgx
-fa7382fd8b2e788b28b807e200dd95b9  file1.jp2-c0.tif
-ed79b7fe443955cdefba2b039ddc846a  file1.jp2-c0_1_2.tif
-ac8f6ab3acc9c692ed7c41bd62a0e1e8  file1.jp2-c0-r1.tif
-fbfcf662b6f7549574b2885490fbcf12  file1.jp2-c0-d10_20_30_40.tif
-fa7382fd8b2e788b28b807e200dd95b9  file1.jp2-c0-t0.tif
-ac8f6ab3acc9c692ed7c41bd62a0e1e8  file1.jp2-c0-t0-r1.tif
+6e23ded7d3ca0b1dd8405448e3ff931b  file1.jp2-c0.png
+5acabea0ef6d09d2c1f681773e886935  file1.jp2-c0_1_2.png
+1150acbee2c1e33c57592c05c76e565a  file1.jp2-c0-r1.png
+1b8ab42d8ee4e28d2868c04a815fb569  file1.jp2-c0-d10_20_30_40.png
+6e23ded7d3ca0b1dd8405448e3ff931b  file1.jp2-c0-t0.png
+1150acbee2c1e33c57592c05c76e565a  file1.jp2-c0-t0-r1.png
 f31bcb01c771f829054cdb013575e86a  issue1043.png
 62bc654c830efddf1b23d6e208447dab  tnsot_zero.png

--- a/tests/nonregression/test_suite.ctest.in
+++ b/tests/nonregression/test_suite.ctest.in
@@ -612,22 +612,22 @@ opj_decompress -i @INPUT_NR_PATH@/issue979.j2k -o @TEMP_PATH@/issue979.j2k.pgx
 opj_decompress -i @INPUT_NR_PATH@/dwt_interleave_h.gsr105.jp2 -o @TEMP_PATH@/dwt_interleave_h.gsr105.jp2_d_1_1_33_33.pgx -d 1,1,33,33
 
 # partial component decoding with opj_decode(): one component
-opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0.tif -c 0
+opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0.png -c 0
 # partial component decoding with opj_decode(): 3 components without MCT
-opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0_1_2.tif -c 0,1,2
+opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0_1_2.png -c 0,1,2
 # partial component decoding with opj_decode() and opj_set_decode_area()
-opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0-d10_20_30_40.tif -c 0 -d 10,20,30,40
+opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0-d10_20_30_40.png -c 0 -d 10,20,30,40
 # partial component decoding with opj_decode() and reduced resolution
-opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0-r1.tif -c 0 -r 1
+opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0-r1.png -c 0 -r 1
 # partial component decoding with opj_get_decoded_tile()
-opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0-t0.tif -c 0 -t 0
+opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0-t0.png -c 0 -t 0
 # partial component decoding with opj_get_decoded_tile() and reduced resolution
-opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0-t0-r1.tif -c 0 -t 0 -r 1
+opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0-t0-r1.png -c 0 -t 0 -r 1
 
 # try to map the same component several times
-!opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0_0.tif -c 0,0
+!opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c0_0.png -c 0,0
 # try to map an invalid component
-!opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c10.tif -c 10
+!opj_decompress -i @INPUT_CONF_PATH@/file1.jp2 -o @TEMP_PATH@/file1.jp2-c10.png -c 10
 
 opj_decompress -i @INPUT_NR_PATH@/db11217111510058.jp2 -o @TEMP_PATH@/issue1043.png
 


### PR DESCRIPTION
Fixes #1233

libtiff 4.1 slightly modifies the way it generates files. So
add the new expected md5sum.

Not super elegant solution admitedly.