### PR TITLE
opj_decompress: add sanity checks to avoid segfault in case of decoding error

### DIFF
--- a/src/bin/jp2/convert.c
+++ b/src/bin/jp2/convert.c
@@ -2067,10 +2067,26 @@ int imagetopnm(opj_image_t * image, const char *outfile, int force_split)
         has_alpha = (ncomp == 4 || ncomp == 2);
 
         red = image->comps[0].data;
+        if (red == NULL) {
+            fprintf(stderr,
+                    "imagetopnm: planes[%d] == NULL.\n", 0);
+            fprintf(stderr, "\tAborting\n");
+            fclose(fdest);
+            return fails;
+        }
 
         if (triple) {
             green = image->comps[1].data;
             blue = image->comps[2].data;
+            for (i = 1; i <= 2; i++) {
+                if (image->comps[i].data == NULL) {
+                    fprintf(stderr,
+                            "imagetopnm: planes[%d] == NULL.\n", i);
+                    fprintf(stderr, "\tAborting\n");
+                    fclose(fdest);
+                    return fails;
+                }
+            }
         } else {
             green = blue = NULL;
         }

--- a/src/bin/jp2/convertpng.c
+++ b/src/bin/jp2/convertpng.c
@@ -297,6 +297,12 @@ int imagetopng(opj_image_t * image, const char *write_idf)
     memset(&sig_bit, 0, sizeof(sig_bit));
     prec = (int)image->comps[0].prec;
     planes[0] = image->comps[0].data;
+    if (planes[0] == NULL) {
+        fprintf(stderr,
+                "imagetopng: planes[%d] == NULL.\n", 0);
+        fprintf(stderr, "\tAborting\n");
+        return 1;
+    }
     nr_comp = (int)image->numcomps;
 
     if (nr_comp > 4) {
@@ -316,6 +322,12 @@ int imagetopng(opj_image_t * image, const char *write_idf)
             break;
         }
         planes[i] = image->comps[i].data;
+        if (planes[i] == NULL) {
+            fprintf(stderr,
+                    "imagetopng: planes[%d] == NULL.\n", i);
+            fprintf(stderr, "\tAborting\n");
+            return 1;
+        }
     }
     if (i != nr_comp) {
         fprintf(stderr,

--- a/src/bin/jp2/converttif.c
+++ b/src/bin/jp2/converttif.c
@@ -616,6 +616,12 @@ int imagetotif(opj_image_t * image, const char *outfile)
             break;
         }
         planes[i] = image->comps[i].data;
+        if (planes[i] == NULL) {
+            fprintf(stderr,
+                    "imagetotif: planes[%d] == NULL.\n", i);
+            fprintf(stderr, "\tAborting\n");
+            return 1;
+        }
     }
     if (i != numcomps) {
         fprintf(stderr,


### PR DESCRIPTION
Prevent crashes like:
opj_decompress -i 0722_5-1_2019.jp2 -o out.ppm -r 4 -t 0

where 0722_5-1_2019.jp2 is
https://drive.google.com/file/d/1ZxOUZg2-FKjYwa257VFLMpTXRWxEoP0a/view?usp=sharing