### PR TITLE
openjp2: Error out if failing to create Tier 1 handle.

### DIFF
--- a/src/lib/openjp2/t1.c
+++ b/src/lib/openjp2/t1.c
@@ -1658,6 +1658,13 @@ static void opj_t1_clbl_decode_processor(void* user_data, opj_tls_t* tls)
     t1 = (opj_t1_t*) opj_tls_get(tls, OPJ_TLS_KEY_T1);
     if (t1 == NULL) {
         t1 = opj_t1_create(OPJ_FALSE);
+        if (t1 == NULL) {
+            opj_event_msg(job->p_manager, EVT_ERROR,
+                          "Cannot allocate Tier 1 handle\n");
+            *(job->pret) = OPJ_FALSE;
+            opj_free(job);
+            return;
+        }
         opj_tls_set(tls, OPJ_TLS_KEY_T1, t1, opj_t1_destroy_wrapper);
     }
     t1->mustuse_cblkdatabuffer = job->mustuse_cblkdatabuffer;


### PR DESCRIPTION
Previously when the handle failed to be created (e.g. when
opj_calloc returned NULL due to low memory), the code still
assumed that the t1 handle pointer was valid and dereferenced
NULL, causing a crash. After this commit OpenJPEG will instead
error out under this condition.

This fixes issue #1255.