### PR TITLE
Free p_tcd_marker_info to avoid memory leak

### DIFF
--- a/src/lib/openjp2/tcd.c
+++ b/src/lib/openjp2/tcd.c
@@ -2851,6 +2851,7 @@ void opj_tcd_marker_info_destroy(opj_tcd_marker_info_t *p_tcd_marker_info)
 {
     if (p_tcd_marker_info) {
         opj_free(p_tcd_marker_info->p_packet_size);
+        opj_free(p_tcd_marker_info);
     }
 }
 


### PR DESCRIPTION
It has a memory leak when using opj_compress with `-PLT`.
```
➜  ~ /openjpeg/build/bin/opj_compress -i ./sample.png  -o ./a.j2c  -PLT

[INFO] tile number 1 / 1
[INFO] Generated outfile ./a.j2c
encode time: 2 ms 

=================================================================
==25432==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7fb179289d28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7fb178f807d9 in opj_tcd_marker_info_create /home/yuan/openjpeg/src/lib/openjp2/tcd.c:2837

SUMMARY: AddressSanitizer: 16 byte(s) leaked in 1 allocation(s).

```
It has to free marker_info in opj_j2k_write_sod in lib/openjp2/j2k.c before return.