### PR TITLE
Set parameters->irreversible = 0 to avoid buffer-overflow

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -7730,6 +7730,7 @@ OPJ_BOOL opj_j2k_setup_encoder(opj_j2k_t *p_j2k,
         opj_j2k_set_imf_parameters(parameters, image, p_manager);
         if (!opj_j2k_is_imf_compliant(parameters, image, p_manager)) {
             parameters->rsiz = OPJ_PROFILE_NONE;
+            parameters->irreversible = 0;
         }
     } else if (OPJ_IS_PART2(parameters->rsiz)) {
         if (parameters->rsiz == ((OPJ_PROFILE_PART2) | (OPJ_EXTENSION_NONE))) {


### PR DESCRIPTION
When using `-IMF`, it set `parameters->irreversible = 1` in j2k:6984
```c
if (profile == OPJ_PROFILE_IMF_2K ||
            profile == OPJ_PROFILE_IMF_4K ||
            profile == OPJ_PROFILE_IMF_8K) {
        /* 9-7 transform */
        parameters->irreversible = 1;
    }
```
However, when `opj_j2k_is_imf_compliant` return `OPJ_FALSE` to use Non-IMF codestream, it doesn't set `parameters->irreversible` to zero in j2k:7732
```c
        if (!opj_j2k_is_imf_compliant(parameters, image, p_manager)) {
            parameters->rsiz = OPJ_PROFILE_NONE;
            // parameters->irreversible = 0;  <- fix
        }
```
So in `opj_dwt_calc_explicit_stepsizes` in dwt.c:1963, it does IMF code to cause buffer-over-flow.
```c
        if (tccp->qntsty == J2K_CCP_QNTSTY_NOQNT) {
            stepsize = 1.0;
        } else {
            OPJ_FLOAT64 norm = opj_dwt_norms_real[orient][level];
            stepsize = (1 << (gain)) / norm;
        }
```