### PR TITLE
Use INC_DIR for OPENJPEG_INCLUDE_DIRS (fixes uclouvain#1174)

### DIFF
--- a/cmake/OpenJPEGConfig.cmake.in
+++ b/cmake/OpenJPEGConfig.cmake.in
@@ -27,12 +27,8 @@ if(EXISTS ${SELF_DIR}/OpenJPEGTargets.cmake)
   # This is an install tree
   include(${SELF_DIR}/OpenJPEGTargets.cmake)
 
-  # We find a relative path from the PKG directory to header files.
-  set(PKG_DIR "@CMAKE_INSTALL_PREFIX@/@OPENJPEG_INSTALL_PACKAGE_DIR@")
   set(INC_DIR "@CMAKE_INSTALL_PREFIX@/@OPENJPEG_INSTALL_INCLUDE_DIR@")
-  file(RELATIVE_PATH PKG_TO_INC_RPATH "${PKG_DIR}" "${INC_DIR}")
-
-  get_filename_component(OPENJPEG_INCLUDE_DIRS "${SELF_DIR}/${PKG_TO_INC_RPATH}" ABSOLUTE)
+  get_filename_component(OPENJPEG_INCLUDE_DIRS "${INC_DIR}" ABSOLUTE)
 
 else()
   if(EXISTS ${SELF_DIR}/OpenJPEGExports.cmake)


### PR DESCRIPTION
This fixes the case where the cmake file is accessed via a symlink.

I'm not sure I understand the original code and why all the complexity is needed. If we do need all that, then we may need to canonicalize SELF_DIR.