### PR TITLE
Set ${OPENJPEG_INSTALL_DOC_DIR} to DESTINATION of HTMLs

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -44,7 +44,7 @@ if(DOXYGEN_FOUND)
 
   # install HTML documentation (install png files too):
   install(DIRECTORY ${CMAKE_BINARY_DIR}/doc/html
-    DESTINATION share/doc
+    DESTINATION ${OPENJPEG_INSTALL_DOC_DIR}
     PATTERN ".svn" EXCLUDE
   )
 else()


### PR DESCRIPTION
Use `${OPENJPEG_INSTALL_DOC_DIR}` as `DESTINATION` of HTML documents, instead of `share/doc`.