### PR TITLE
docs: fix simple typo, producted -> produced

### DIFF
--- a/thirdparty/include/zlib.h
+++ b/thirdparty/include/zlib.h
@@ -487,7 +487,7 @@ ZEXTERN int ZEXPORT inflate OF((z_streamp strm, int flush));
   instead use raw inflate, see inflateInit2() below, or inflateBack() and
   perform their own processing of the gzip header and trailer.  When processing
   gzip-wrapped deflate data, strm->adler32 is set to the CRC-32 of the output
-  producted so far.  The CRC-32 is checked against the gzip trailer.
+  produced so far.  The CRC-32 is checked against the gzip trailer.
 
     inflate() returns Z_OK if some progress has been made (more input processed
   or more output produced), Z_STREAM_END if the end of the compressed data has

--- a/thirdparty/libz/zlib.h
+++ b/thirdparty/libz/zlib.h
@@ -487,7 +487,7 @@ ZEXTERN int ZEXPORT inflate OF((z_streamp strm, int flush));
   instead use raw inflate, see inflateInit2() below, or inflateBack() and
   perform their own processing of the gzip header and trailer.  When processing
   gzip-wrapped deflate data, strm->adler32 is set to the CRC-32 of the output
-  producted so far.  The CRC-32 is checked against the gzip trailer.
+  produced so far.  The CRC-32 is checked against the gzip trailer.
 
     inflate() returns Z_OK if some progress has been made (more input processed
   or more output produced), Z_STREAM_END if the end of the compressed data has


### PR DESCRIPTION
There is a small typo in thirdparty/include/zlib.h, thirdparty/libz/zlib.h.

Should read `produced` rather than `producted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md