### PR TITLE
CMakeLists.txt: Don't require a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 #string(TOLOWER ${OPENJPEG_NAMESPACE} OPENJPEG_LIBRARY_NAME)
 set(OPENJPEG_LIBRARY_NAME openjp2)
 
-project(${OPENJPEG_NAMESPACE})
+project(${OPENJPEG_NAMESPACE} C)
 
 # Do full dependency headers.
 include_regular_expression("^.*$")

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -120,5 +120,6 @@ endif(BUILD_THIRDPARTY)
 
 #------------
 IF (WITH_ASTYLE)
+  enable_language(CXX)
   ADD_SUBDIRECTORY(astyle)
 ENDIF(WITH_ASTYLE)


### PR DESCRIPTION
By default, CMake assumes that the project is using both C and C++.  By
explicitly passing 'C' as argument of the project() macro, we tell CMake
that only C is used, which prevents CMake from erroring out if a C++
compiler doesn't exist.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
[Retrieved (and slightly updated by adding enable_language(CXX) if
WITH_ASTYLE is set) from:
https://git.buildroot.net/buildroot/tree/package/openjpeg/0003-CMakeLists.txt-Don-t-require-a-C-compiler.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>