### PR TITLE
openmj2/opj_includes.h: Do not define 'lrintf' on MSVC since 16.9.2

### DIFF
--- a/src/lib/openmj2/opj_includes.h
+++ b/src/lib/openmj2/opj_includes.h
@@ -92,7 +92,7 @@ Most compilers implement their own version of this keyword ...
 #endif
 
 /* MSVC and Borland C do not have lrintf */
-#if defined(_MSC_VER) || defined(__BORLANDC__)
+#if (defined(_MSC_VER) && (_MSC_FULL_VER < 192829913)) || defined(__BORLANDC__)
 static INLINE long lrintf(float f)
 {
 #ifdef _M_X64


### PR DESCRIPTION
This PR adds a minor fix for building with Visual Studio 16.9 ore newer. The newer versions have a builtin lrintf, so the current code was giving error:
```
[...]\src\lib\openmj2\opj_includes.h(97): error C2169: 'lrintf': intrinsic function, cannot be defined
```

This PR closes #1333 