### PR TITLE
emscripten: disable big endian test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,8 +162,10 @@ endif()
 
 #-----------------------------------------------------------------------------
 # Big endian test:
+if (!EMSCRIPTEN)
 include (${CMAKE_ROOT}/Modules/TestBigEndian.cmake)
 TEST_BIG_ENDIAN(OPJ_BIG_ENDIAN)
+endif()
 
 #-----------------------------------------------------------------------------
 # Setup file for setting custom ctest vars


### PR DESCRIPTION
Hi, 

I think this test should not run on the emscripten platform because of :
https://github.com/emscripten-core/emscripten/blob/dff33368427fba16745c8ce52f11484a67b2855d/cmake/Modules/TestBigEndian.cmake#L5

changing CMAKE_ROOT to point to `..,/emsdk/upstream/emscripten/cmake` does not solve the issue, as there are some .cmake files that are needed and are not on emsdk.