### PR TITLE
opj_{compress,decompress,dump}: fix possible buffer overflows in path manipulation functions

### DIFF
--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1912,9 +1912,9 @@ int main(int argc, char **argv)
         num_images = get_num_images(img_fol.imgdirpath);
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (dirptr) {
-            dirptr->filename_buf = (char*)malloc(num_images * OPJ_PATH_LEN * sizeof(
+            dirptr->filename_buf = (char*)calloc(num_images, OPJ_PATH_LEN * sizeof(
                     char)); /* Stores at max 10 image file names*/
-            dirptr->filename = (char**) malloc(num_images * sizeof(char*));
+            dirptr->filename = (char**) calloc(num_images, sizeof(char*));
             if (!dirptr->filename_buf) {
                 ret = 0;
                 goto fin;

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -543,8 +543,8 @@ static char * get_file_name(char *name)
 static char get_next_file(int imageno, dircnt_t *dirptr, img_fol_t *img_fol,
                           opj_cparameters_t *parameters)
 {
-    char image_filename[OPJ_PATH_LEN], infilename[OPJ_PATH_LEN],
-         outfilename[OPJ_PATH_LEN], temp_ofname[OPJ_PATH_LEN];
+    char image_filename[OPJ_PATH_LEN], infilename[OPJ_PATH_LEN * 2],
+         outfilename[OPJ_PATH_LEN * 2], temp_ofname[OPJ_PATH_LEN];
     char *temp_p, temp1[OPJ_PATH_LEN] = "";
 
     strcpy(image_filename, dirptr->filename[imageno]);
@@ -553,7 +553,7 @@ static char get_next_file(int imageno, dircnt_t *dirptr, img_fol_t *img_fol,
     if (parameters->decod_format == -1) {
         return 1;
     }
-    sprintf(infilename, "%s/%s", img_fol->imgdirpath, image_filename);
+    snprintf(infilename, OPJ_PATH_LEN * 2, "%s/%s", img_fol->imgdirpath, image_filename);
     if (opj_strcpy_s(parameters->infile, sizeof(parameters->infile),
                      infilename) != 0) {
         return 1;
@@ -566,7 +566,7 @@ static char get_next_file(int imageno, dircnt_t *dirptr, img_fol_t *img_fol,
         sprintf(temp1, ".%s", temp_p);
     }
     if (img_fol->set_out_format == 1) {
-        sprintf(outfilename, "%s/%s.%s", img_fol->imgdirpath, temp_ofname,
+        snprintf(outfilename, OPJ_PATH_LEN * 2, "%s/%s.%s", img_fol->imgdirpath, temp_ofname,
                 img_fol->out_format);
         if (opj_strcpy_s(parameters->outfile, sizeof(parameters->outfile),
                          outfilename) != 0) {

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -455,13 +455,13 @@ const char* path_separator = "/";
 char get_next_file(int imageno, dircnt_t *dirptr, img_fol_t *img_fol,
                    opj_decompress_parameters *parameters)
 {
-    char image_filename[OPJ_PATH_LEN], infilename[OPJ_PATH_LEN],
-         outfilename[OPJ_PATH_LEN], temp_ofname[OPJ_PATH_LEN];
+    char image_filename[OPJ_PATH_LEN], infilename[OPJ_PATH_LEN * 2],
+         outfilename[OPJ_PATH_LEN * 2], temp_ofname[OPJ_PATH_LEN];
     char *temp_p, temp1[OPJ_PATH_LEN] = "";
 
     strcpy(image_filename, dirptr->filename[imageno]);
     fprintf(stderr, "File Number %d \"%s\"\n", imageno, image_filename);
-    sprintf(infilename, "%s%s%s", img_fol->imgdirpath, path_separator,
+    snprintf(infilename, OPJ_PATH_LEN * 2, "%s%s%s", img_fol->imgdirpath, path_separator,
             image_filename);
     parameters->decod_format = infile_format(infilename);
     if (parameters->decod_format == -1) {
@@ -479,7 +479,7 @@ char get_next_file(int imageno, dircnt_t *dirptr, img_fol_t *img_fol,
         sprintf(temp1, ".%s", temp_p);
     }
     if (img_fol->set_out_format == 1) {
-        sprintf(outfilename, "%s/%s.%s", img_fol->imgdirpath, temp_ofname,
+        snprintf(outfilename, OPJ_PATH_LEN * 2, "%s/%s.%s", img_fol->imgdirpath, temp_ofname,
                 img_fol->out_format);
         if (opj_strcpy_s(parameters->outfile, sizeof(parameters->outfile),
                          outfilename) != 0) {

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1350,14 +1350,13 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
         /* Stores at max 10 image file names */
-        dirptr->filename_buf = (char*)malloc(sizeof(char) *
-                                             (size_t)num_images * OPJ_PATH_LEN);
+        dirptr->filename_buf = calloc((size_t) num_images, sizeof(char) * OPJ_PATH_LEN);
         if (!dirptr->filename_buf) {
             failed = 1;
             goto fin;
         }
 
-        dirptr->filename = (char**) malloc((size_t)num_images * sizeof(char*));
+        dirptr->filename = (char**) calloc((size_t) num_images, sizeof(char*));
 
         if (!dirptr->filename) {
             failed = 1;

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -457,7 +457,7 @@ int main(int argc, char *argv[])
     opj_codestream_info_v2_t* cstr_info = NULL;
     opj_codestream_index_t* cstr_index = NULL;
 
-    OPJ_INT32 num_images, imageno;
+    int num_images, imageno;
     img_fol_t img_fol;
     dircnt_t *dirptr = NULL;
 
@@ -486,13 +486,13 @@ int main(int argc, char *argv[])
         if (!dirptr) {
             return EXIT_FAILURE;
         }
-        dirptr->filename_buf = (char*)malloc((size_t)num_images * OPJ_PATH_LEN * sizeof(
+        dirptr->filename_buf = (char*) calloc((size_t) num_images, OPJ_PATH_LEN * sizeof(
                 char)); /* Stores at max 10 image file names*/
         if (!dirptr->filename_buf) {
             free(dirptr);
             return EXIT_FAILURE;
         }
-        dirptr->filename = (char**) malloc((size_t)num_images * sizeof(char*));
+        dirptr->filename = (char**) calloc((size_t) num_images, sizeof(char*));
 
         if (!dirptr->filename) {
             goto fails;

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -201,8 +201,8 @@ static int get_file_format(const char *filename)
 static char get_next_file(int imageno, dircnt_t *dirptr, img_fol_t *img_fol,
                           opj_dparameters_t *parameters)
 {
-    char image_filename[OPJ_PATH_LEN], infilename[OPJ_PATH_LEN],
-         outfilename[OPJ_PATH_LEN], temp_ofname[OPJ_PATH_LEN];
+    char image_filename[OPJ_PATH_LEN], infilename[OPJ_PATH_LEN * 2],
+         outfilename[OPJ_PATH_LEN * 2], temp_ofname[OPJ_PATH_LEN];
     char *temp_p, temp1[OPJ_PATH_LEN] = "";
 
     strcpy(image_filename, dirptr->filename[imageno]);
@@ -211,7 +211,7 @@ static char get_next_file(int imageno, dircnt_t *dirptr, img_fol_t *img_fol,
     if (parameters->decod_format == -1) {
         return 1;
     }
-    sprintf(infilename, "%s/%s", img_fol->imgdirpath, image_filename);
+    snprintf(infilename, OPJ_PATH_LEN * 2, "%s/%s", img_fol->imgdirpath, image_filename);
     if (opj_strcpy_s(parameters->infile, sizeof(parameters->infile),
                      infilename) != 0) {
         return 1;
@@ -224,7 +224,7 @@ static char get_next_file(int imageno, dircnt_t *dirptr, img_fol_t *img_fol,
         sprintf(temp1, ".%s", temp_p);
     }
     if (img_fol->set_out_format == 1) {
-        sprintf(outfilename, "%s/%s.%s", img_fol->imgdirpath, temp_ofname,
+        snprintf(outfilename, OPJ_PATH_LEN * 2, "%s/%s.%s", img_fol->imgdirpath, temp_ofname,
                 img_fol->out_format);
         if (opj_strcpy_s(parameters->outfile, sizeof(parameters->outfile),
                          outfilename) != 0) {


### PR DESCRIPTION
If `img_fol->imgdirpath` is itself of `OPJ_PATH_LEN` length, other buffers on the stack will be overwritten by the image filename.

Any output of a function where paths are concatenated should likely be `OBJ_PATH_LEN * 2`, but I did not change this as it would cause an ABI break.