### PR TITLE
fix #1345: don't remove big endian test for other platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 
 #-----------------------------------------------------------------------------
 # Big endian test:
-if (!EMSCRIPTEN)
+if (NOT EMSCRIPTEN)
 include (${CMAKE_ROOT}/Modules/TestBigEndian.cmake)
 TEST_BIG_ENDIAN(OPJ_BIG_ENDIAN)
 endif()


### PR DESCRIPTION
thank you to  @ePirat for finding the issue, it turns out that !EMSCRIPTEN does not evaluate to 1 on other platforms, so the the #1345 actually disabled the test for all platforms.

sorry about the churn