### PR TITLE
API: deprecate 'bpp' member in favor of 'prec'

### DIFF
--- a/src/bin/jp2/convert.c
+++ b/src/bin/jp2/convert.c
@@ -117,7 +117,6 @@ static void scale_component_up(opj_image_comp_t* component,
         }
     }
     component->prec = precision;
-    component->bpp = precision;
 }
 void scale_component(opj_image_comp_t* component, OPJ_UINT32 precision)
 {
@@ -144,7 +143,6 @@ void scale_component(opj_image_comp_t* component, OPJ_UINT32 precision)
             l_data[i] >>= shift;
         }
     }
-    component->bpp = precision;
     component->prec = precision;
 }
 
@@ -838,7 +836,6 @@ opj_image_t* tgatoimage(const char *filename, opj_cparameters_t *parameters)
 
     for (i = 0; i < numcomps; i++) {
         cmptparm[i].prec = 8;
-        cmptparm[i].bpp = 8;
         cmptparm[i].sgnd = 0;
         cmptparm[i].dx = (OPJ_UINT32)subsampling_dx;
         cmptparm[i].dy = (OPJ_UINT32)subsampling_dy;
@@ -1269,7 +1266,6 @@ opj_image_t* pgxtoimage(const char *filename, opj_cparameters_t *parameters)
     }
 
     cmptparm.prec = (OPJ_UINT32)prec;
-    cmptparm.bpp = (OPJ_UINT32)prec;
     cmptparm.dx = (OPJ_UINT32)parameters->subsampling_dx;
     cmptparm.dy = (OPJ_UINT32)parameters->subsampling_dy;
 
@@ -1327,7 +1323,7 @@ opj_image_t* pgxtoimage(const char *filename, opj_cparameters_t *parameters)
         comp->data[i] = v;
     }
     fclose(f);
-    comp->bpp = (OPJ_UINT32)int_floorlog2(max) + 1;
+    comp->prec = (OPJ_UINT32)int_floorlog2(max) + 1;
 
     return image;
 }
@@ -1875,7 +1871,6 @@ opj_image_t* pnmtoimage(const char *filename, opj_cparameters_t *parameters)
 
     for (i = 0; i < numcomps; i++) {
         cmptparm[i].prec = (OPJ_UINT32)prec;
-        cmptparm[i].bpp = (OPJ_UINT32)prec;
         cmptparm[i].sgnd = 0;
         cmptparm[i].dx = (OPJ_UINT32)subsampling_dx;
         cmptparm[i].dy = (OPJ_UINT32)subsampling_dy;
@@ -2366,7 +2361,6 @@ static opj_image_t* rawtoimage_common(const char *filename,
     /* initialize image components */
     for (i = 0; i < numcomps; i++) {
         cmptparm[i].prec = (OPJ_UINT32)raw_cp->rawBitDepth;
-        cmptparm[i].bpp = (OPJ_UINT32)raw_cp->rawBitDepth;
         cmptparm[i].sgnd = (OPJ_UINT32)raw_cp->rawSigned;
         cmptparm[i].dx = (OPJ_UINT32)(subsampling_dx * raw_cp->rawComps[i].dx);
         cmptparm[i].dy = (OPJ_UINT32)(subsampling_dy * raw_cp->rawComps[i].dy);

--- a/src/bin/jp2/convertbmp.c
+++ b/src/bin/jp2/convertbmp.c
@@ -198,14 +198,10 @@ static void bmpmask32toimage(const OPJ_UINT8* pData, OPJ_UINT32 stride,
     bmp_mask_get_shift_and_prec(blueMask,  &blueShift,  &bluePrec);
     bmp_mask_get_shift_and_prec(alphaMask, &alphaShift, &alphaPrec);
 
-    image->comps[0].bpp = redPrec;
     image->comps[0].prec = redPrec;
-    image->comps[1].bpp = greenPrec;
     image->comps[1].prec = greenPrec;
-    image->comps[2].bpp = bluePrec;
     image->comps[2].prec = bluePrec;
     if (hasAlpha) {
-        image->comps[3].bpp = alphaPrec;
         image->comps[3].prec = alphaPrec;
     }
 
@@ -260,14 +256,10 @@ static void bmpmask16toimage(const OPJ_UINT8* pData, OPJ_UINT32 stride,
     bmp_mask_get_shift_and_prec(blueMask,  &blueShift,  &bluePrec);
     bmp_mask_get_shift_and_prec(alphaMask, &alphaShift, &alphaPrec);
 
-    image->comps[0].bpp = redPrec;
     image->comps[0].prec = redPrec;
-    image->comps[1].bpp = greenPrec;
     image->comps[1].prec = greenPrec;
-    image->comps[2].bpp = bluePrec;
     image->comps[2].prec = bluePrec;
     if (hasAlpha) {
-        image->comps[3].bpp = alphaPrec;
         image->comps[3].prec = alphaPrec;
     }
 
@@ -838,7 +830,6 @@ opj_image_t* bmptoimage(const char *filename, opj_cparameters_t *parameters)
     memset(&cmptparm[0], 0, sizeof(cmptparm));
     for (i = 0; i < 4U; i++) {
         cmptparm[i].prec = 8;
-        cmptparm[i].bpp  = 8;
         cmptparm[i].sgnd = 0;
         cmptparm[i].dx   = (OPJ_UINT32)parameters->subsampling_dx;
         cmptparm[i].dy   = (OPJ_UINT32)parameters->subsampling_dy;

--- a/src/bin/jp2/convertpng.c
+++ b/src/bin/jp2/convertpng.c
@@ -193,9 +193,8 @@ static opj_image_t * pngtoimage_internal(opj_cparameters_t * params,
         /* Create image */
         memset(cmptparm, 0, sizeof(cmptparm));
         for (i = 0; i < nr_comp; ++i) {
-            cmptparm[i].prec = (OPJ_UINT32)bit_depth;
             /* bits_per_pixel: 8 or 16 */
-            cmptparm[i].bpp = (OPJ_UINT32)bit_depth;
+            cmptparm[i].prec = (OPJ_UINT32)bit_depth;
             cmptparm[i].sgnd = 0;
             cmptparm[i].dx = (OPJ_UINT32)params->subsampling_dx;
             cmptparm[i].dy = (OPJ_UINT32)params->subsampling_dy;

--- a/src/bin/jp2/converttif.c
+++ b/src/bin/jp2/converttif.c
@@ -1389,7 +1389,6 @@ opj_image_t* tiftoimage(const char *filename, opj_cparameters_t *parameters)
 
     for (j = 0; j < numcomps; j++) {
         cmptparm[j].prec = tiBps;
-        cmptparm[j].bpp = tiBps;
         cmptparm[j].dx = (OPJ_UINT32)subsampling_dx;
         cmptparm[j].dy = (OPJ_UINT32)subsampling_dy;
         cmptparm[j].w = (OPJ_UINT32)w;

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1086,8 +1086,6 @@ static opj_image_t* convert_gray_to_rgb(opj_image_t* original)
         return NULL;
     }
 
-    l_new_components[0].bpp  = l_new_components[1].bpp  = l_new_components[2].bpp  =
-                                   original->comps[0].bpp;
     l_new_components[0].dx   = l_new_components[1].dx   = l_new_components[2].dx   =
                                    original->comps[0].dx;
     l_new_components[0].dy   = l_new_components[1].dy   = l_new_components[2].dy   =
@@ -1106,7 +1104,6 @@ static opj_image_t* convert_gray_to_rgb(opj_image_t* original)
                                    original->comps[0].y0;
 
     for (compno = 1U; compno < original->numcomps; ++compno) {
-        l_new_components[compno + 2U].bpp  = original->comps[compno].bpp;
         l_new_components[compno + 2U].dx   = original->comps[compno].dx;
         l_new_components[compno + 2U].dy   = original->comps[compno].dy;
         l_new_components[compno + 2U].h    = original->comps[compno].h;
@@ -1196,7 +1193,6 @@ static opj_image_t* upsample_image_components(opj_image_t* original)
         opj_image_cmptparm_t* l_new_cmp = &(l_new_components[compno]);
         opj_image_comp_t*     l_org_cmp = &(original->comps[compno]);
 
-        l_new_cmp->bpp  = l_org_cmp->bpp;
         l_new_cmp->prec = l_org_cmp->prec;
         l_new_cmp->sgnd = l_org_cmp->sgnd;
         l_new_cmp->x0   = original->x0;

--- a/src/lib/openjp2/image.c
+++ b/src/lib/openjp2/image.c
@@ -66,7 +66,6 @@ opj_image_t* OPJ_CALLCONV opj_image_create(OPJ_UINT32 numcmpts,
             comp->x0 = cmptparms[compno].x0;
             comp->y0 = cmptparms[compno].y0;
             comp->prec = cmptparms[compno].prec;
-            comp->bpp = cmptparms[compno].bpp;
             comp->sgnd = cmptparms[compno].sgnd;
             if (comp->h != 0 &&
                     (OPJ_SIZE_T)comp->w > SIZE_MAX / comp->h / sizeof(OPJ_INT32)) {

--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -6975,7 +6975,7 @@ static OPJ_BOOL opj_j2k_is_cinema_compliant(opj_image_t *image, OPJ_UINT16 rsiz,
 
     /* Bitdepth */
     for (i = 0; i < image->numcomps; i++) {
-        if ((image->comps[i].bpp != 12) | (image->comps[i].sgnd)) {
+        if ((image->comps[i].prec != 12) | (image->comps[i].sgnd)) {
             char signed_str[] = "signed";
             char unsigned_str[] = "unsigned";
             char *tmp_str = image->comps[i].sgnd ? signed_str : unsigned_str;
@@ -6984,7 +6984,7 @@ static OPJ_BOOL opj_j2k_is_cinema_compliant(opj_image_t *image, OPJ_UINT16 rsiz,
                           "Precision of each component shall be 12 bits unsigned"
                           "-> At least component %d of input image (%d bits, %s) is not compliant\n"
                           "-> Non-profile-3 codestream will be generated\n",
-                          i, image->comps[i].bpp, tmp_str);
+                          i, image->comps[i].prec, tmp_str);
             return OPJ_FALSE;
         }
     }
@@ -7275,7 +7275,7 @@ static OPJ_BOOL opj_j2k_is_imf_compliant(opj_cparameters_t *parameters,
 
     /* Bitdepth */
     for (i = 0; i < image->numcomps; i++) {
-        if (!(image->comps[i].bpp >= 8 && image->comps[i].bpp <= 16) ||
+        if (!(image->comps[i].prec >= 8 && image->comps[i].prec <= 16) ||
                 (image->comps[i].sgnd)) {
             char signed_str[] = "signed";
             char unsigned_str[] = "unsigned";
@@ -7284,7 +7284,7 @@ static OPJ_BOOL opj_j2k_is_imf_compliant(opj_cparameters_t *parameters,
                           "IMF profiles require precision of each component to b in [8-16] bits unsigned"
                           "-> At least component %d of input image (%d bits, %s) is not compliant\n"
                           "-> Non-IMF codestream will be generated\n",
-                          i, image->comps[i].bpp, tmp_str);
+                          i, image->comps[i].prec, tmp_str);
             ret = OPJ_FALSE;
         }
     }

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -76,6 +76,12 @@ Most compilers implement their own version of this keyword ...
 #define OPJ_DEPRECATED(func) func
 #endif
 
+#if defined(__GNUC__) && __GNUC__ >= 6
+#define OPJ_DEPRECATED_STRUCT_MEMBER(memb, msg) __attribute__ ((deprecated(msg))) memb
+#else
+#define OPJ_DEPRECATED_STRUCT_MEMBER(memb, msg) memb
+#endif
+
 #if defined(OPJ_STATIC) || !defined(_WIN32)
 /* http://gcc.gnu.org/wiki/Visibility */
 #   if !defined(_WIN32) && __GNUC__ >= 4
@@ -681,10 +687,10 @@ typedef struct opj_image_comp {
     OPJ_UINT32 x0;
     /** y component offset compared to the whole image */
     OPJ_UINT32 y0;
-    /** precision */
+    /** precision: number of bits per component per pixel */
     OPJ_UINT32 prec;
-    /** image depth in bits */
-    OPJ_UINT32 bpp;
+    /** obsolete: use prec instead */
+    OPJ_DEPRECATED_STRUCT_MEMBER(OPJ_UINT32 bpp, "Use prec instead");
     /** signed (1) / unsigned (0) */
     OPJ_UINT32 sgnd;
     /** number of decoded resolution */
@@ -738,10 +744,10 @@ typedef struct opj_image_comptparm {
     OPJ_UINT32 x0;
     /** y component offset compared to the whole image */
     OPJ_UINT32 y0;
-    /** precision */
+    /** precision: number of bits per component per pixel */
     OPJ_UINT32 prec;
-    /** image depth in bits */
-    OPJ_UINT32 bpp;
+    /** obsolete: use prec instead */
+    OPJ_DEPRECATED_STRUCT_MEMBER(OPJ_UINT32 bpp, "Use prec instead");
     /** signed (1) / unsigned (0) */
     OPJ_UINT32 sgnd;
 } opj_image_cmptparm_t;

--- a/tests/compare_images.c
+++ b/tests/compare_images.c
@@ -225,7 +225,6 @@ static opj_image_t* readImageFromFilePPM(const char* filename,
         param_image_read[it_file].dy = 0;
         param_image_read[it_file].h = image_read->comps->h;
         param_image_read[it_file].w = image_read->comps->w;
-        param_image_read[it_file].bpp = image_read->comps->bpp;
         param_image_read[it_file].prec = image_read->comps->prec;
         param_image_read[it_file].sgnd = image_read->comps->sgnd;
 
@@ -356,7 +355,6 @@ static opj_image_t* readImageFromFilePGX(const char* filename,
         param_image_read[it_file].dy = 0;
         param_image_read[it_file].h = image_read->comps->h;
         param_image_read[it_file].w = image_read->comps->w;
-        param_image_read[it_file].bpp = image_read->comps->bpp;
         param_image_read[it_file].prec = image_read->comps->prec;
         param_image_read[it_file].sgnd = image_read->comps->sgnd;
 
@@ -403,7 +401,6 @@ static int imageToPNG(const opj_image_t* image, const char* filename,
     param_image_write.dy = 0;
     param_image_write.h = image->comps[num_comp_select].h;
     param_image_write.w = image->comps[num_comp_select].w;
-    param_image_write.bpp = image->comps[num_comp_select].bpp;
     param_image_write.prec = image->comps[num_comp_select].prec;
     param_image_write.sgnd = image->comps[num_comp_select].sgnd;
 
@@ -797,7 +794,6 @@ int main(int argc, char **argv)
         param_image_diff[it_comp].dy = 0;
         param_image_diff[it_comp].sgnd = 0;
         param_image_diff[it_comp].prec = 8;
-        param_image_diff[it_comp].bpp = 1;
         param_image_diff[it_comp].h = imageBase->comps[it_comp].h;
         param_image_diff[it_comp].w = imageBase->comps[it_comp].w;
 
@@ -811,13 +807,6 @@ int main(int argc, char **argv)
                 !inParam.ignore_prec) {
             printf("ERROR: prec mismatch [comp %d] (%d><%d)\n", it_comp,
                    ((imageBase->comps)[it_comp]).prec, ((imageTest->comps)[it_comp]).prec);
-            goto cleanup;
-        }
-
-        if (((imageBase->comps)[it_comp]).bpp != ((imageTest->comps)[it_comp]).bpp &&
-                !inParam.ignore_prec) {
-            printf("ERROR: bit per pixel mismatch [comp %d] (%d><%d)\n", it_comp,
-                   ((imageBase->comps)[it_comp]).bpp, ((imageTest->comps)[it_comp]).bpp);
             goto cleanup;
         }
 
@@ -856,12 +845,12 @@ int main(int argc, char **argv)
         double MSE = 0;
         unsigned right_shift_input = 0;
         unsigned right_shift_output = 0;
-        if (((imageBase->comps)[it_comp]).bpp > ((imageTest->comps)[it_comp]).bpp) {
-            right_shift_input = ((imageBase->comps)[it_comp]).bpp - ((
-                                    imageTest->comps)[it_comp]).bpp;
+        if (((imageBase->comps)[it_comp]).prec > ((imageTest->comps)[it_comp]).prec) {
+            right_shift_input = ((imageBase->comps)[it_comp]).prec - ((
+                                    imageTest->comps)[it_comp]).prec;
         } else {
-            right_shift_output = ((imageTest->comps)[it_comp]).bpp - ((
-                                     imageBase->comps)[it_comp]).bpp;
+            right_shift_output = ((imageTest->comps)[it_comp]).prec - ((
+                                     imageBase->comps)[it_comp]).prec;
         }
         for (itpxl = 0;
                 itpxl < ((imageDiff->comps)[it_comp]).w * ((imageDiff->comps)[it_comp]).h;

--- a/tests/unit/testempty1.c
+++ b/tests/unit/testempty1.c
@@ -82,7 +82,6 @@ int main(int argc, char *argv[])
     parameters.cod_format = J2K_CFMT;
     puts(v);
     cmptparm.prec = 8;
-    cmptparm.bpp = 8;
     cmptparm.sgnd = 0;
     cmptparm.dx = subsampling_dx;
     cmptparm.dy = subsampling_dy;

--- a/tests/unit/testempty2.c
+++ b/tests/unit/testempty2.c
@@ -86,7 +86,6 @@ int main(int argc, char *argv[])
     subsampling_dx = (unsigned int)parameters.subsampling_dx;
     subsampling_dy = (unsigned int)parameters.subsampling_dy;
     cmptparm.prec = 8;
-    cmptparm.bpp = 8;
     cmptparm.sgnd = 0;
     cmptparm.dx = subsampling_dx;
     cmptparm.dy = subsampling_dy;


### PR DESCRIPTION
in opj_image_comp and opj_image_comptparm structures.

bpp was redundant with prec, and almost never set by the library, except
by opj_image_create(). This change should hopefully not impact existing,
working, users of the API, which should already have used prec to get
things working.

Fixes #1379