### PR TITLE
Allow configuration of the number of guard bits when encoding

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -8202,7 +8202,7 @@ OPJ_BOOL opj_j2k_setup_encoder(opj_j2k_t *p_j2k,
             tccp->qmfbid = parameters->irreversible ? 0 : 1;
             tccp->qntsty = parameters->irreversible ? J2K_CCP_QNTSTY_SEQNT :
                            J2K_CCP_QNTSTY_NOQNT;
-            tccp->numgbits = 2;
+            tccp->numgbits = parameters->numgbits;
 
             if ((OPJ_INT32)i == parameters->roi_compno) {
                 tccp->roishift = parameters->roi_shift;

--- a/src/lib/openjp2/openjpeg.c
+++ b/src/lib/openjp2/openjpeg.c
@@ -762,6 +762,7 @@ void OPJ_CALLCONV opj_set_default_encoder_parameters(opj_cparameters_t
         parameters->cp_fixed_alloc = 0;
         parameters->cp_fixed_quality = 0;
         parameters->jpip_on = OPJ_FALSE;
+        parameters->numgbits = 2;
         /* UniPG>> */
 #ifdef USE_JPWL
         parameters->jpwl_epc_on = OPJ_FALSE;

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -448,6 +448,8 @@ typedef struct opj_cparameters {
     int prcw_init[OPJ_J2K_MAXRLVLS];
     /** initial precinct height */
     int prch_init[OPJ_J2K_MAXRLVLS];
+    /** number of guard bits */
+    int numgbits;
 
     /**@name command line encoder parameters (not used inside the library) */
     /*@{*/


### PR DESCRIPTION
The recently-released SMPTE DCP Bv2.1 Application Profile (link below) says that the number of guard bits in the `QCD` marker shall be 1 for 2K content and 2 for 4K content.  This change allows the number of guard bits to be configured, so that users of openjpeg have the control they need to meet the specification.

https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=9161348 