### PR TITLE
Added check for integer overflow in get_num_images 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "cstdlib": "c"
+    }
+}

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1957,6 +1957,11 @@ int main(int argc, char **argv)
     /* Read directory if necessary */
     if (img_fol.set_imgdir == 1) {
         num_images = get_num_images(img_fol.imgdirpath);
+        if((num_images > SIZE_MAX/(OPJ_PATH_LEN * sizeof(char))){
+            fprintf(stdout, "Max images exceeded\n");
+            ret = 0;
+            goto fin;
+        } else {
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (dirptr) {
             dirptr->filename_buf = (char*)calloc(num_images, OPJ_PATH_LEN * sizeof(
@@ -1973,6 +1978,7 @@ int main(int argc, char **argv)
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             ret = 0;
             goto fin;
+        }
         }
         if (num_images == 0) {
             fprintf(stdout, "Folder is empty\n");

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -44,6 +44,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <assert.h>
+#include <limits.h>
 
 #ifdef _WIN32
 #include "windirent.h"
@@ -485,10 +486,10 @@ static unsigned int get_num_images(char *imgdirpath)
         if (strcmp(".", content->d_name) == 0 || strcmp("..", content->d_name) == 0) {
             continue;
         }
-        num_images++;
-        if (num_images == 0) {
+        if (num_images == UINT_MAX) {
             fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
         }
+        num_images++;
     }
     closedir(dir);
     return num_images;

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1957,11 +1957,6 @@ int main(int argc, char **argv)
     /* Read directory if necessary */
     if (img_fol.set_imgdir == 1) {
         num_images = get_num_images(img_fol.imgdirpath);
-        if((num_images > SIZE_MAX/(OPJ_PATH_LEN * sizeof(char)))){
-            fprintf(stdout, "Max images exceeded\n");
-            ret = 0;
-            goto fin;
-        } else {
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (dirptr) {
             dirptr->filename_buf = (char*)calloc(num_images, OPJ_PATH_LEN * sizeof(
@@ -1971,14 +1966,13 @@ int main(int argc, char **argv)
                 ret = 0;
                 goto fin;
             }
-            for (i = 0; i < num_images; i++) {
+            for (size_t i = 0; i < num_images; i++) {
                 dirptr->filename[i] = dirptr->filename_buf + i * OPJ_PATH_LEN;
             }
         }
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             ret = 0;
             goto fin;
-        }
         }
         if (num_images == 0) {
             fprintf(stdout, "Folder is empty\n");

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -486,6 +486,9 @@ static unsigned int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
+        if (num_images == 0) {
+            fprintf(stderr,"Too many files in folder %s\n", imgdirpath);
+        }
     }
     closedir(dir);
     return num_images;
@@ -1957,6 +1960,11 @@ int main(int argc, char **argv)
     /* Read directory if necessary */
     if (img_fol.set_imgdir == 1) {
         num_images = get_num_images(img_fol.imgdirpath);
+        if (num_images == 0) {
+            fprintf(stdout, "Folder is empty\n");
+            ret = 0;
+            goto fin;
+        }
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (dirptr) {
             dirptr->filename_buf = (char*)calloc(num_images, OPJ_PATH_LEN * sizeof(
@@ -1974,11 +1982,7 @@ int main(int argc, char **argv)
             ret = 0;
             goto fin;
         }
-        if (num_images == 0) {
-            fprintf(stdout, "Folder is empty\n");
-            ret = 0;
-            goto fin;
-        }
+
     } else {
         num_images = 1;
     }

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -488,7 +488,8 @@ static unsigned int get_num_images(char *imgdirpath)
         }
         if (num_images == UINT_MAX) {
             fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
-            return 0;
+            num_images = 0;
+            break;
         }
         num_images++;
     }

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -488,6 +488,7 @@ static unsigned int get_num_images(char *imgdirpath)
         }
         if (num_images == UINT_MAX) {
             fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
+            return 0;
         }
         num_images++;
     }

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1957,7 +1957,7 @@ int main(int argc, char **argv)
     /* Read directory if necessary */
     if (img_fol.set_imgdir == 1) {
         num_images = get_num_images(img_fol.imgdirpath);
-        if((num_images > SIZE_MAX/(OPJ_PATH_LEN * sizeof(char)))){
+        if(num_images > SIZE_MAX/(OPJ_PATH_LEN * sizeof(char)) || num_images < 0){
             fprintf(stdout, "Max images exceeded\n");
             ret = 0;
             goto fin;

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1959,9 +1959,9 @@ int main(int argc, char **argv)
         num_images = get_num_images(img_fol.imgdirpath);
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (dirptr) {
-            dirptr->filename_buf = (char*)malloc(num_images * OPJ_PATH_LEN * sizeof(
+            dirptr->filename_buf = (char*)calloc(num_images, OPJ_PATH_LEN * sizeof(
                     char)); /* Stores at max 10 image file names*/
-            dirptr->filename = (char**) malloc(num_images * sizeof(char*));
+            dirptr->filename = (char**) calloc(num_images, sizeof(char*));
             if (!dirptr->filename_buf) {
                 ret = 0;
                 goto fin;

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1957,11 +1957,6 @@ int main(int argc, char **argv)
     /* Read directory if necessary */
     if (img_fol.set_imgdir == 1) {
         num_images = get_num_images(img_fol.imgdirpath);
-        if(num_images > SIZE_MAX/(OPJ_PATH_LEN * sizeof(char)) || num_images < 0){
-            fprintf(stdout, "Max images exceeded\n");
-            ret = 0;
-            goto fin;
-        } else {
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (dirptr) {
             dirptr->filename_buf = (char*)calloc(num_images, OPJ_PATH_LEN * sizeof(
@@ -1972,13 +1967,12 @@ int main(int argc, char **argv)
                 goto fin;
             }
             for (i = 0; i < num_images; i++) {
-                dirptr->filename[i] = dirptr->filename_buf + i * OPJ_PATH_LEN;
+                dirptr->filename[i] = dirptr->filename_buf + (size_t)i * OPJ_PATH_LEN;
             }
         }
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             ret = 0;
             goto fin;
-        }
         }
         if (num_images == 0) {
             fprintf(stdout, "Folder is empty\n");

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -487,7 +487,7 @@ static unsigned int get_num_images(char *imgdirpath)
         }
         num_images++;
         if (num_images == 0) {
-            fprintf(stderr,"Too many files in folder %s\n", imgdirpath);
+            fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
         }
     }
     closedir(dir);

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1957,7 +1957,7 @@ int main(int argc, char **argv)
     /* Read directory if necessary */
     if (img_fol.set_imgdir == 1) {
         num_images = get_num_images(img_fol.imgdirpath);
-        if((num_images > SIZE_MAX/(OPJ_PATH_LEN * sizeof(char))){
+        if((num_images > SIZE_MAX/(OPJ_PATH_LEN * sizeof(char)))){
             fprintf(stdout, "Max images exceeded\n");
             ret = 0;
             goto fin;

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1957,6 +1957,11 @@ int main(int argc, char **argv)
     /* Read directory if necessary */
     if (img_fol.set_imgdir == 1) {
         num_images = get_num_images(img_fol.imgdirpath);
+        if((num_images > SIZE_MAX/(OPJ_PATH_LEN * sizeof(char)))){
+            fprintf(stdout, "Max images exceeded\n");
+            ret = 0;
+            goto fin;
+        } else {
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (dirptr) {
             dirptr->filename_buf = (char*)calloc(num_images, OPJ_PATH_LEN * sizeof(
@@ -1966,13 +1971,14 @@ int main(int argc, char **argv)
                 ret = 0;
                 goto fin;
             }
-            for (size_t i = 0; i < num_images; i++) {
+            for (i = 0; i < num_images; i++) {
                 dirptr->filename[i] = dirptr->filename_buf + i * OPJ_PATH_LEN;
             }
         }
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             ret = 0;
             goto fin;
+        }
         }
         if (num_images == 0) {
             fprintf(stdout, "Folder is empty\n");

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -486,7 +486,7 @@ static unsigned int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
-        if (num_images == 0) {
+        if(num_images == 0) {
             fprintf(stderr, "Integer overflow detected when reading %s\n", imgdirpath);
             return 0;
         }

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -486,10 +486,6 @@ static unsigned int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
-        if(num_images == 0) {
-            fprintf(stderr, "Integer overflow detected when reading %s\n", imgdirpath);
-            return 0;
-        }
     }
     closedir(dir);
     return num_images;
@@ -1961,11 +1957,6 @@ int main(int argc, char **argv)
     /* Read directory if necessary */
     if (img_fol.set_imgdir == 1) {
         num_images = get_num_images(img_fol.imgdirpath);
-        if (num_images == 0) {
-            fprintf(stdout, "Folder is empty\n");
-            ret = 0;
-            goto fin;
-        }
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (dirptr) {
             dirptr->filename_buf = (char*)calloc(num_images, OPJ_PATH_LEN * sizeof(
@@ -1983,7 +1974,11 @@ int main(int argc, char **argv)
             ret = 0;
             goto fin;
         }
-
+        if (num_images == 0) {
+            fprintf(stdout, "Folder is empty\n");
+            ret = 0;
+            goto fin;
+        }
     } else {
         num_images = 1;
     }

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -486,7 +486,7 @@ static unsigned int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
-        if(num_images == 0) {
+        if (num_images == 0) {
             fprintf(stderr, "Integer overflow detected when reading %s\n", imgdirpath);
             return 0;
         }

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -486,6 +486,10 @@ static unsigned int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
+        if(num_images == 0) {
+            fprintf(stderr, "Integer overflow detected when reading %s\n", imgdirpath);
+            return 0;
+        }
     }
     closedir(dir);
     return num_images;
@@ -1957,6 +1961,11 @@ int main(int argc, char **argv)
     /* Read directory if necessary */
     if (img_fol.set_imgdir == 1) {
         num_images = get_num_images(img_fol.imgdirpath);
+        if (num_images == 0) {
+            fprintf(stdout, "Folder is empty\n");
+            ret = 0;
+            goto fin;
+        }
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (dirptr) {
             dirptr->filename_buf = (char*)calloc(num_images, OPJ_PATH_LEN * sizeof(
@@ -1974,11 +1983,7 @@ int main(int argc, char **argv)
             ret = 0;
             goto fin;
         }
-        if (num_images == 0) {
-            fprintf(stdout, "Folder is empty\n");
-            ret = 0;
-            goto fin;
-        }
+
     } else {
         num_images = 1;
     }

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1386,8 +1386,8 @@ int main(int argc, char **argv)
             goto fin;
         }
         for (it_image = 0; it_image < num_images; it_image++) {
-            dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image * 
-            OPJ_PATH_LEN;
+             dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image *
+                                          OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -390,7 +390,7 @@ int get_num_images(char *imgdirpath)
         }
         num_images++;
         if (num_images == 0) {
-            fprintf(stderr,"Too many files in folder %s\n", imgdirpath);
+            fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
         }
     }
     closedir(dir);

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1365,13 +1365,7 @@ int main(int argc, char **argv)
 
     /* Initialize reading of directory */
     if (img_fol.set_imgdir == 1) {
-        int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
-        if( num_images > SIZE_MAX/(sizeof(char)* OPJ_PATH_LEN)){
-             fprintf(stderr, "Max number of images exceeded\n");
-             failed = 1;
-             goto fin;
-        } else {
         dirptr = (dircnt_t*)calloc(1, sizeof(dircnt_t));
         if (!dirptr) {
             destroy_parameters(&parameters);
@@ -1390,14 +1384,13 @@ int main(int argc, char **argv)
             failed = 1;
             goto fin;
         }
-        for (it_image = 0; it_image < num_images; it_image++) {
+        for (size_t it_image = 0; it_image < num_images; it_image++) {
             dirptr->filename[it_image] = dirptr->filename_buf + it_image * OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             failed = 1;
             goto fin;
-        }
         }
         if (num_images == 0) {
             fprintf(stderr, "Folder is empty\n");

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1374,14 +1374,13 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
         /* Stores at max 10 image file names */
-        dirptr->filename_buf = (char*)malloc(sizeof(char) *
-                                             (size_t)num_images * OPJ_PATH_LEN);
+        dirptr->filename_buf = calloc((size_t) num_images, sizeof(char) * OPJ_PATH_LEN);
         if (!dirptr->filename_buf) {
             failed = 1;
             goto fin;
         }
 
-        dirptr->filename = (char**) malloc((size_t)num_images * sizeof(char*));
+        dirptr->filename = (char**) calloc((size_t) num_images, sizeof(char*));
 
         if (!dirptr->filename) {
             failed = 1;

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1386,8 +1386,8 @@ int main(int argc, char **argv)
             goto fin;
         }
         for (it_image = 0; it_image < num_images; it_image++) {
-             dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image *
-                                          OPJ_PATH_LEN;
+            dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image *
+                                         OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -391,7 +391,7 @@ unsigned int get_num_images(char *imgdirpath)
         }
         if (num_images == UINT_MAX) {
             fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
-            return 0; 
+            return 0;
         }
         num_images++;
 

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -374,7 +374,7 @@ int get_num_images(char *imgdirpath)
 {
     DIR *dir;
     struct dirent* content;
-    int num_images = 0;
+    unsigned int num_images = 0;
 
     /*Reading the input images from given input directory*/
 
@@ -389,6 +389,10 @@ int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
+        if(num_images == 0) {
+            fprintf(stderr, "Integer overflow detected when reading %s\n", imgdirpath);
+            return 0;
+        }
     }
     closedir(dir);
     return num_images;
@@ -1367,6 +1371,11 @@ int main(int argc, char **argv)
     if (img_fol.set_imgdir == 1) {
         int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
+        if (num_images == 0) {
+            fprintf(stderr, "Folder is empty\n");
+            failed = 1;
+            goto fin;
+        }
         dirptr = (dircnt_t*)calloc(1, sizeof(dircnt_t));
         if (!dirptr) {
             destroy_parameters(&parameters);
@@ -1394,11 +1403,7 @@ int main(int argc, char **argv)
             failed = 1;
             goto fin;
         }
-        if (num_images == 0) {
-            fprintf(stderr, "Folder is empty\n");
-            failed = 1;
-            goto fin;
-        }
+
     } else {
         num_images = 1;
     }

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1367,7 +1367,6 @@ int main(int argc, char **argv)
     if (img_fol.set_imgdir == 1) {
         int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
-        
         dirptr = (dircnt_t*)calloc(1, sizeof(dircnt_t));
         if (!dirptr) {
             destroy_parameters(&parameters);
@@ -1387,7 +1386,8 @@ int main(int argc, char **argv)
             goto fin;
         }
         for (it_image = 0; it_image < num_images; it_image++) {
-            dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image * OPJ_PATH_LEN;
+            dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image * 
+            OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -389,7 +389,7 @@ int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
-        if (num_images == 0) {
+        if(num_images == 0) {
             fprintf(stderr, "Integer overflow detected when reading %s\n", imgdirpath);
             return 0;
         }

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -391,7 +391,8 @@ unsigned int get_num_images(char *imgdirpath)
         }
         if (num_images == UINT_MAX) {
             fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
-            return 0;
+            num_images = 0;
+            break;
         }
         num_images++;
 

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1367,7 +1367,11 @@ int main(int argc, char **argv)
     if (img_fol.set_imgdir == 1) {
         int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
-
+        if( num_images > SIZE_MAX/(sizeof(char)* OPJ_PATH_LEN)){
+             fprintf(stderr, "Max number of images exceeded\n");
+             failed = 1;
+             goto fin;
+        } else {
         dirptr = (dircnt_t*)calloc(1, sizeof(dircnt_t));
         if (!dirptr) {
             destroy_parameters(&parameters);
@@ -1393,6 +1397,7 @@ int main(int argc, char **argv)
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             failed = 1;
             goto fin;
+        }
         }
         if (num_images == 0) {
             fprintf(stderr, "Folder is empty\n");

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -44,6 +44,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <time.h>
+#include <limits.h>
 
 #ifdef _WIN32
 #include "windirent.h"
@@ -160,7 +161,7 @@ typedef struct opj_decompress_params {
 
 /* -------------------------------------------------------------------------- */
 /* Declarations                                                               */
-int get_num_images(char *imgdirpath);
+unsigned int get_num_images(char *imgdirpath);
 int load_images(dircnt_t *dirptr, char *imgdirpath);
 int get_file_format(const char *filename);
 char get_next_file(int imageno, dircnt_t *dirptr, img_fol_t *img_fol,
@@ -370,7 +371,7 @@ static OPJ_BOOL parse_precision(const char* option,
 
 /* -------------------------------------------------------------------------- */
 
-int get_num_images(char *imgdirpath)
+unsigned int get_num_images(char *imgdirpath)
 {
     DIR *dir;
     struct dirent* content;
@@ -388,10 +389,11 @@ int get_num_images(char *imgdirpath)
         if (strcmp(".", content->d_name) == 0 || strcmp("..", content->d_name) == 0) {
             continue;
         }
-        num_images++;
-        if (num_images == 0) {
+        if (num_images == UINT_MAX) {
             fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
         }
+        num_images++;
+
     }
     closedir(dir);
     return num_images;

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1365,7 +1365,13 @@ int main(int argc, char **argv)
 
     /* Initialize reading of directory */
     if (img_fol.set_imgdir == 1) {
+        int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
+        if( num_images > SIZE_MAX/(sizeof(char)* OPJ_PATH_LEN)){
+             fprintf(stderr, "Max number of images exceeded\n");
+             failed = 1;
+             goto fin;
+        } else {
         dirptr = (dircnt_t*)calloc(1, sizeof(dircnt_t));
         if (!dirptr) {
             destroy_parameters(&parameters);
@@ -1384,13 +1390,14 @@ int main(int argc, char **argv)
             failed = 1;
             goto fin;
         }
-        for (size_t it_image = 0; it_image < num_images; it_image++) {
+        for (it_image = 0; it_image < num_images; it_image++) {
             dirptr->filename[it_image] = dirptr->filename_buf + it_image * OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             failed = 1;
             goto fin;
+        }
         }
         if (num_images == 0) {
             fprintf(stderr, "Folder is empty\n");

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1367,11 +1367,7 @@ int main(int argc, char **argv)
     if (img_fol.set_imgdir == 1) {
         int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
-        if( num_images > SIZE_MAX/(sizeof(char)* OPJ_PATH_LEN) || num_images < 0){
-             fprintf(stderr, "Max number of images exceeded\n");
-             failed = 1;
-             goto fin;
-        } else {
+        
         dirptr = (dircnt_t*)calloc(1, sizeof(dircnt_t));
         if (!dirptr) {
             destroy_parameters(&parameters);
@@ -1391,13 +1387,12 @@ int main(int argc, char **argv)
             goto fin;
         }
         for (it_image = 0; it_image < num_images; it_image++) {
-            dirptr->filename[it_image] = dirptr->filename_buf + it_image * OPJ_PATH_LEN;
+            dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image * OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             failed = 1;
             goto fin;
-        }
         }
         if (num_images == 0) {
             fprintf(stderr, "Folder is empty\n");

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -391,6 +391,7 @@ unsigned int get_num_images(char *imgdirpath)
         }
         if (num_images == UINT_MAX) {
             fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
+            return 0; 
         }
         num_images++;
 

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -1367,7 +1367,7 @@ int main(int argc, char **argv)
     if (img_fol.set_imgdir == 1) {
         int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
-        if( num_images > SIZE_MAX/(sizeof(char)* OPJ_PATH_LEN)){
+        if( num_images > SIZE_MAX/(sizeof(char)* OPJ_PATH_LEN) || num_images < 0){
              fprintf(stderr, "Max number of images exceeded\n");
              failed = 1;
              goto fin;

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -389,7 +389,7 @@ int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
-        if(num_images == 0) {
+        if (num_images == 0) {
             fprintf(stderr, "Integer overflow detected when reading %s\n", imgdirpath);
             return 0;
         }

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -374,7 +374,7 @@ int get_num_images(char *imgdirpath)
 {
     DIR *dir;
     struct dirent* content;
-    int num_images = 0;
+    unsigned int num_images = 0;
 
     /*Reading the input images from given input directory*/
 
@@ -389,6 +389,9 @@ int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
+        if (num_images == 0) {
+            fprintf(stderr,"Too many files in folder %s\n", imgdirpath);
+        }
     }
     closedir(dir);
     return num_images;
@@ -1367,6 +1370,11 @@ int main(int argc, char **argv)
     if (img_fol.set_imgdir == 1) {
         int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
+        if (num_images == 0) {
+            fprintf(stderr, "Folder is empty\n");
+            failed = 1;
+            goto fin;
+        }
         dirptr = (dircnt_t*)calloc(1, sizeof(dircnt_t));
         if (!dirptr) {
             destroy_parameters(&parameters);
@@ -1394,11 +1402,7 @@ int main(int argc, char **argv)
             failed = 1;
             goto fin;
         }
-        if (num_images == 0) {
-            fprintf(stderr, "Folder is empty\n");
-            failed = 1;
-            goto fin;
-        }
+
     } else {
         num_images = 1;
     }

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -374,7 +374,7 @@ int get_num_images(char *imgdirpath)
 {
     DIR *dir;
     struct dirent* content;
-    unsigned int num_images = 0;
+    int num_images = 0;
 
     /*Reading the input images from given input directory*/
 
@@ -389,10 +389,6 @@ int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
-        if(num_images == 0) {
-            fprintf(stderr, "Integer overflow detected when reading %s\n", imgdirpath);
-            return 0;
-        }
     }
     closedir(dir);
     return num_images;
@@ -1371,11 +1367,6 @@ int main(int argc, char **argv)
     if (img_fol.set_imgdir == 1) {
         int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
-        if (num_images == 0) {
-            fprintf(stderr, "Folder is empty\n");
-            failed = 1;
-            goto fin;
-        }
         dirptr = (dircnt_t*)calloc(1, sizeof(dircnt_t));
         if (!dirptr) {
             destroy_parameters(&parameters);
@@ -1403,7 +1394,11 @@ int main(int argc, char **argv)
             failed = 1;
             goto fin;
         }
-
+        if (num_images == 0) {
+            fprintf(stderr, "Folder is empty\n");
+            failed = 1;
+            goto fin;
+        }
     } else {
         num_images = 1;
     }

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -515,13 +515,14 @@ int main(int argc, char *argv[])
         if (!dirptr) {
             return EXIT_FAILURE;
         }
-        dirptr->filename_buf = (char*)malloc((size_t)num_images * OPJ_PATH_LEN * sizeof(
-                char)); /* Stores at max 10 image file names*/
+        /* Stores at max 10 image file names*/
+        dirptr->filename_buf = (char*) calloc((size_t) num_images,
+                                              OPJ_PATH_LEN * sizeof(char));
         if (!dirptr->filename_buf) {
             free(dirptr);
             return EXIT_FAILURE;
         }
-        dirptr->filename = (char**) malloc((size_t)num_images * sizeof(char*));
+        dirptr->filename = (char**) calloc((size_t) num_images, sizeof(char*));
 
         if (!dirptr->filename) {
             goto fails;

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -141,9 +141,8 @@ static int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
-        if (num_images == 0) {
-            fprintf(stderr, "Integer overflow detected when reading images from %s\n",
-                    imgdirpath);
+        if(num_images == 0) {
+            fprintf(stderr, "Integer overflow detected when reading images from %s\n", imgdirpath);
             return 0;
         }
     }

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
+#include <limits.h>
 
 #ifdef _WIN32
 #include "windirent.h"
@@ -82,7 +83,7 @@ typedef struct img_folder {
 
 /* -------------------------------------------------------------------------- */
 /* Declarations                                                               */
-static int get_num_images(char *imgdirpath);
+static unsigned int get_num_images(char *imgdirpath);
 static int load_images(dircnt_t *dirptr, char *imgdirpath);
 static int get_file_format(const char *filename);
 static char get_next_file(int imageno, dircnt_t *dirptr, img_fol_t *img_fol,
@@ -122,7 +123,7 @@ static void decode_help_display(void)
 }
 
 /* -------------------------------------------------------------------------- */
-static int get_num_images(char *imgdirpath)
+static unsigned int get_num_images(char *imgdirpath)
 {
     DIR *dir;
     struct dirent* content;
@@ -140,10 +141,10 @@ static int get_num_images(char *imgdirpath)
         if (strcmp(".", content->d_name) == 0 || strcmp("..", content->d_name) == 0) {
             continue;
         }
-        num_images++;
-        if (num_images == 0) {
+        if (num_images == UINT_MAX) {
             fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
         }
+        num_images++;
     }
     closedir(dir);
     return num_images;

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -141,8 +141,9 @@ static int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
-        if(num_images == 0) {
-            fprintf(stderr, "Integer overflow detected when reading images from %s\n", imgdirpath);
+        if (num_images == 0) {
+            fprintf(stderr, "Integer overflow detected when reading images from %s\n",
+                    imgdirpath);
             return 0;
         }
     }

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -126,7 +126,7 @@ static int get_num_images(char *imgdirpath)
 {
     DIR *dir;
     struct dirent* content;
-    int num_images = 0;
+    unsigned int num_images = 0;
 
     /*Reading the input images from given input directory*/
 
@@ -141,6 +141,10 @@ static int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
+        if(num_images == 0) {
+            fprintf(stderr, "Integer overflow detected when reading images from %s\n", imgdirpath);
+            return 0;
+        }
     }
     closedir(dir);
     return num_images;
@@ -510,7 +514,10 @@ int main(int argc, char *argv[])
     if (img_fol.set_imgdir == 1) {
         int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
-
+        if (num_images == 0) {
+            fprintf(stdout, "Folder is empty\n");
+            goto fails;
+        }
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (!dirptr) {
             return EXIT_FAILURE;
@@ -536,10 +543,7 @@ int main(int argc, char *argv[])
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             goto fails;
         }
-        if (num_images == 0) {
-            fprintf(stdout, "Folder is empty\n");
-            goto fails;
-        }
+
     } else {
         num_images = 1;
     }

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -516,7 +516,7 @@ int main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
         /* Stores at max 10 image file names*/
-        if(num_images> SIZE_MAX/(OPJ_PATH_LEN * sizeof(char))){
+        if(num_images> SIZE_MAX/(OPJ_PATH_LEN * sizeof(char)) || num_images < 0){
             free(dirptr);
             return EXIT_FAILURE;
         }else{

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -508,6 +508,7 @@ int main(int argc, char *argv[])
 
     /* Initialize reading of directory */
     if (img_fol.set_imgdir == 1) {
+        int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
 
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
@@ -515,6 +516,10 @@ int main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
         /* Stores at max 10 image file names*/
+        if(num_images> SIZE_MAX/(OPJ_PATH_LEN * sizeof(char))){
+            free(dirptr);
+            return EXIT_FAILURE;
+        }else{
         dirptr->filename_buf = (char*) calloc((size_t) num_images,
                                               OPJ_PATH_LEN * sizeof(char));
         if (!dirptr->filename_buf) {
@@ -527,12 +532,13 @@ int main(int argc, char *argv[])
             goto fails;
         }
 
-        for (size_t it_image = 0; it_image < num_images; it_image++) {
+        for (it_image = 0; it_image < num_images; it_image++) {
             dirptr->filename[it_image] = dirptr->filename_buf + it_image * OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             goto fails;
+        }
         }
         if (num_images == 0) {
             fprintf(stdout, "Folder is empty\n");

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -529,7 +529,7 @@ int main(int argc, char *argv[])
         }
 
         for (it_image = 0; it_image < num_images; it_image++) {
-            dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image * 
+            dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image *
                                          OPJ_PATH_LEN;
         }
 

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -529,7 +529,8 @@ int main(int argc, char *argv[])
         }
 
         for (it_image = 0; it_image < num_images; it_image++) {
-            dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image * OPJ_PATH_LEN;
+            dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image * 
+                                          OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -516,6 +516,10 @@ int main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
         /* Stores at max 10 image file names*/
+        if(num_images> SIZE_MAX/(OPJ_PATH_LEN * sizeof(char))){
+            free(dirptr);
+            return EXIT_FAILURE;
+        }else{
         dirptr->filename_buf = (char*) calloc((size_t) num_images,
                                               OPJ_PATH_LEN * sizeof(char));
         if (!dirptr->filename_buf) {
@@ -535,7 +539,7 @@ int main(int argc, char *argv[])
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             goto fails;
         }
-
+        }
         if (num_images == 0) {
             fprintf(stdout, "Folder is empty\n");
             goto fails;

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -516,10 +516,6 @@ int main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
         /* Stores at max 10 image file names*/
-        if(num_images> SIZE_MAX/(OPJ_PATH_LEN * sizeof(char)) || num_images < 0){
-            free(dirptr);
-            return EXIT_FAILURE;
-        }else{
         dirptr->filename_buf = (char*) calloc((size_t) num_images,
                                               OPJ_PATH_LEN * sizeof(char));
         if (!dirptr->filename_buf) {
@@ -533,12 +529,11 @@ int main(int argc, char *argv[])
         }
 
         for (it_image = 0; it_image < num_images; it_image++) {
-            dirptr->filename[it_image] = dirptr->filename_buf + it_image * OPJ_PATH_LEN;
+            dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image * OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             goto fails;
-        }
         }
         if (num_images == 0) {
             fprintf(stdout, "Folder is empty\n");

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -126,7 +126,7 @@ static int get_num_images(char *imgdirpath)
 {
     DIR *dir;
     struct dirent* content;
-    int num_images = 0;
+    unsigned int num_images = 0;
 
     /*Reading the input images from given input directory*/
 
@@ -141,6 +141,9 @@ static int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
+        if (num_images == 0) {
+            fprintf(stderr,"Too many files in folder %s\n", imgdirpath);
+        }
     }
     closedir(dir);
     return num_images;
@@ -510,7 +513,10 @@ int main(int argc, char *argv[])
     if (img_fol.set_imgdir == 1) {
         int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
-
+        if (num_images == 0) {
+            fprintf(stdout, "Folder is empty\n");
+            goto fails;
+        }
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (!dirptr) {
             return EXIT_FAILURE;
@@ -536,10 +542,7 @@ int main(int argc, char *argv[])
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             goto fails;
         }
-        if (num_images == 0) {
-            fprintf(stdout, "Folder is empty\n");
-            goto fails;
-        }
+
     } else {
         num_images = 1;
     }

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -530,7 +530,7 @@ int main(int argc, char *argv[])
 
         for (it_image = 0; it_image < num_images; it_image++) {
             dirptr->filename[it_image] = dirptr->filename_buf + (size_t)it_image * 
-                                          OPJ_PATH_LEN;
+                                         OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -143,7 +143,8 @@ static unsigned int get_num_images(char *imgdirpath)
         }
         if (num_images == UINT_MAX) {
             fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
-            return 0;
+            num_images = 0;
+            break;
         }
         num_images++;
     }

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -508,7 +508,6 @@ int main(int argc, char *argv[])
 
     /* Initialize reading of directory */
     if (img_fol.set_imgdir == 1) {
-        int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
 
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
@@ -516,10 +515,6 @@ int main(int argc, char *argv[])
             return EXIT_FAILURE;
         }
         /* Stores at max 10 image file names*/
-        if(num_images> SIZE_MAX/(OPJ_PATH_LEN * sizeof(char))){
-            free(dirptr);
-            return EXIT_FAILURE;
-        }else{
         dirptr->filename_buf = (char*) calloc((size_t) num_images,
                                               OPJ_PATH_LEN * sizeof(char));
         if (!dirptr->filename_buf) {
@@ -532,13 +527,12 @@ int main(int argc, char *argv[])
             goto fails;
         }
 
-        for (it_image = 0; it_image < num_images; it_image++) {
+        for (size_t it_image = 0; it_image < num_images; it_image++) {
             dirptr->filename[it_image] = dirptr->filename_buf + it_image * OPJ_PATH_LEN;
         }
 
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             goto fails;
-        }
         }
         if (num_images == 0) {
             fprintf(stdout, "Folder is empty\n");

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -143,6 +143,7 @@ static unsigned int get_num_images(char *imgdirpath)
         }
         if (num_images == UINT_MAX) {
             fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
+            return 0;
         }
         num_images++;
     }

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -126,7 +126,7 @@ static int get_num_images(char *imgdirpath)
 {
     DIR *dir;
     struct dirent* content;
-    unsigned int num_images = 0;
+    int num_images = 0;
 
     /*Reading the input images from given input directory*/
 
@@ -141,10 +141,6 @@ static int get_num_images(char *imgdirpath)
             continue;
         }
         num_images++;
-        if(num_images == 0) {
-            fprintf(stderr, "Integer overflow detected when reading images from %s\n", imgdirpath);
-            return 0;
-        }
     }
     closedir(dir);
     return num_images;
@@ -514,10 +510,7 @@ int main(int argc, char *argv[])
     if (img_fol.set_imgdir == 1) {
         int it_image;
         num_images = get_num_images(img_fol.imgdirpath);
-        if (num_images == 0) {
-            fprintf(stdout, "Folder is empty\n");
-            goto fails;
-        }
+
         dirptr = (dircnt_t*)malloc(sizeof(dircnt_t));
         if (!dirptr) {
             return EXIT_FAILURE;
@@ -543,7 +536,10 @@ int main(int argc, char *argv[])
         if (load_images(dirptr, img_fol.imgdirpath) == 1) {
             goto fails;
         }
-
+        if (num_images == 0) {
+            fprintf(stdout, "Folder is empty\n");
+            goto fails;
+        }
     } else {
         num_images = 1;
     }

--- a/src/bin/jp2/opj_dump.c
+++ b/src/bin/jp2/opj_dump.c
@@ -142,7 +142,7 @@ static int get_num_images(char *imgdirpath)
         }
         num_images++;
         if (num_images == 0) {
-            fprintf(stderr,"Too many files in folder %s\n", imgdirpath);
+            fprintf(stderr, "Too many files in folder %s\n", imgdirpath);
         }
     }
     closedir(dir);


### PR DESCRIPTION
As discussed in pull request 1396, added a check for integer overflow. 
Change list:
Defined num_images as unsigned int
Moved the if statement to check for an empty directory to the beginning of the read directory section
Added a check to see if num images rolls back to zero when incrementing. 