### PR TITLE
opj_encoder_set_extra_options(): add a GUARD_BITS=value option

### DIFF
--- a/src/lib/openjp2/j2k.h
+++ b/src/lib/openjp2/j2k.h
@@ -550,6 +550,9 @@ typedef struct opj_j2k_enc {
     /* reserved bytes in m_encoded_tile_size for PLT markers */
     OPJ_UINT32 m_reserved_bytes_for_PLT;
 
+    /** Number of components */
+    OPJ_UINT32 m_nb_comps;
+
 } opj_j2k_enc_t;
 
 

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -1599,9 +1599,12 @@ OPJ_API OPJ_BOOL OPJ_CALLCONV opj_setup_encoder(opj_codec_t *p_codec,
  * <li>PLT=YES/NO. Defaults to NO. If set to YES, PLT marker segments,
  *     indicating the length of each packet in the tile-part header, will be
  *     written. Since 2.4.0</li>
-  * <li>TLM=YES/NO. Defaults to NO (except for Cinema and IMF profiles).
-  *    If set to YES, TLM marker segments, indicating the length of each
-  *    tile-part part will be written. Since 2.4.0</li>
+ * <li>TLM=YES/NO. Defaults to NO (except for Cinema and IMF profiles).
+ *     If set to YES, TLM marker segments, indicating the length of each
+ *     tile-part part will be written. Since 2.4.0</li>
+ * <li>GUARD_BITS=value. Number of guard bits in [0,7] range. Default value is 2.
+ *     1 may be used sometimes (like in SMPTE DCP Bv2.1 Application Profile for 2K images).
+ *     Since 2.5.0</li>
  * </ul>
  *
  * @param p_codec       Compressor handle


### PR DESCRIPTION
and add a -GuardBits option to opj_compress.

The recently-released SMPTE DCP Bv2.1 Application Profile (link below)
says that the number of guard bits in the QCD marker shall be 1 for 2K
content and 2 for 4K content. This change allows the number of guard bits
to be configured, so that users of openjpeg have the control they need to meet the specification.

https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=9161348

This is an alternative implementation of https://github.com/uclouvain/openjpeg/pull/1388
that keeps ABI unchanged.