### PR TITLE
pkgconfig: Define OPJ_STATIC for static linking with pkgconf

### DIFF
--- a/src/lib/openjp2/libopenjp2.pc.cmake.in
+++ b/src/lib/openjp2/libopenjp2.pc.cmake.in
@@ -12,3 +12,4 @@ Version: @OPENJPEG_VERSION@
 Libs: -L${libdir} -lopenjp2
 Libs.private: -lm
 Cflags: -I${includedir}
+Cflags.private: -DOPJ_STATIC

--- a/src/lib/openjpip/libopenjpip.pc.cmake.in
+++ b/src/lib/openjpip/libopenjpip.pc.cmake.in
@@ -13,3 +13,4 @@ Requires: libopenjp2
 Libs: -L${libdir} -lopenjpip
 Libs.private: -lm -lcurl -lfcgi -lpthread
 Cflags: -I${includedir}
+Cflags.private: -DOPJ_STATIC


### PR DESCRIPTION
allows for the usage of $(pkgconf --static --cflags libopenjp2) to produce
the proper CFLAGS for static linking. Relies on pkgconf rather than pkg-config.