### PR TITLE
Replace the assert in mel_init to an if statement to address an issue with fuzzing.

### DIFF
--- a/src/lib/openjp2/ht_dec.c
+++ b/src/lib/openjp2/ht_dec.c
@@ -317,7 +317,7 @@ OPJ_BOOL mel_init(dec_mel_t *melp, OPJ_UINT8* bbuf, int lcup, int scup)
         int d_bits;
 
         if (melp->unstuff == OPJ_TRUE && melp->data[0] > 0x8F) {
-          return OPJ_FALSE;
+            return OPJ_FALSE;
         }
         d = (melp->size > 0) ? *melp->data : 0xFF; // if buffer is consumed
         // set data to 0xFF
@@ -1378,15 +1378,15 @@ OPJ_BOOL opj_t1_ht_decode_cblk(opj_t1_t *t1,
 
     // init structures
     if (mel_init(&mel, coded_data, lcup, scup) == OPJ_FALSE) {
-      if (p_manager_mutex) {
-        opj_mutex_lock(p_manager_mutex);
-      }
-      opj_event_msg(p_manager, EVT_ERROR, "Malformed HT codeblock. "
-                    "Incorrect MEL segment sequence.\n");
-      if (p_manager_mutex) {
-        opj_mutex_unlock(p_manager_mutex);
-      }
-      return OPJ_FALSE;
+        if (p_manager_mutex) {
+            opj_mutex_lock(p_manager_mutex);
+        }
+        opj_event_msg(p_manager, EVT_ERROR, "Malformed HT codeblock. "
+                      "Incorrect MEL segment sequence.\n");
+        if (p_manager_mutex) {
+            opj_mutex_unlock(p_manager_mutex);
+        }
+        return OPJ_FALSE;
     }
     rev_init(&vlc, coded_data, lcup, scup);
     frwd_init(&magsgn, coded_data, lcup - scup, 0xFF);

--- a/src/lib/openjp2/ht_dec.c
+++ b/src/lib/openjp2/ht_dec.c
@@ -294,7 +294,7 @@ void mel_decode(dec_mel_t *melp)
   *  @param [in]  scup is the length of MEL+VLC segments
   */
 static INLINE
-void mel_init(dec_mel_t *melp, OPJ_UINT8* bbuf, int lcup, int scup)
+OPJ_BOOL mel_init(dec_mel_t *melp, OPJ_UINT8* bbuf, int lcup, int scup)
 {
     int num;
     int i;
@@ -316,7 +316,9 @@ void mel_init(dec_mel_t *melp, OPJ_UINT8* bbuf, int lcup, int scup)
         OPJ_UINT64 d;
         int d_bits;
 
-        assert(melp->unstuff == OPJ_FALSE || melp->data[0] <= 0x8F);
+        if (melp->unstuff == OPJ_TRUE && melp->data[0] > 0x8F) {
+          return OPJ_FALSE;
+        }
         d = (melp->size > 0) ? *melp->data : 0xFF; // if buffer is consumed
         // set data to 0xFF
         if (melp->size == 1) {
@@ -332,6 +334,7 @@ void mel_init(dec_mel_t *melp, OPJ_UINT8* bbuf, int lcup, int scup)
     }
     melp->tmp <<= (64 - melp->bits); //push all the way up so the first bit
     // is the MSB
+    return OPJ_TRUE;
 }
 
 //************************************************************************/
@@ -1374,7 +1377,17 @@ OPJ_BOOL opj_t1_ht_decode_cblk(opj_t1_t *t1,
     }
 
     // init structures
-    mel_init(&mel, coded_data, lcup, scup);
+    if (mel_init(&mel, coded_data, lcup, scup) == OPJ_FALSE) {
+      if (p_manager_mutex) {
+        opj_mutex_lock(p_manager_mutex);
+      }
+      opj_event_msg(p_manager, EVT_ERROR, "Malformed HT codeblock. "
+                    "Incorrect MEL segment sequence.\n");
+      if (p_manager_mutex) {
+        opj_mutex_unlock(p_manager_mutex);
+      }
+      return OPJ_FALSE;
+    }
     rev_init(&vlc, coded_data, lcup, scup);
     frwd_init(&magsgn, coded_data, lcup - scup, 0xFF);
     if (num_passes > 1) { // needs to be tested


### PR DESCRIPTION
Hi Even, Everyone,

This is to address the issue with the Fuzzer in
https://bugs.chromium.org/p/chromium/issues/detail?id=1343737
A wrong sequence should produce erroneous result, but should not cause a crash.
A similar if statement can be added to mel_read(), but this requires more changes -- no fuzzing issue produced for this.

I tried to run openjpeg fuzzing, but I did not know how to tell oss-fuzz what source to use.  I tried
```python infra/helper.py build_fuzzers --architecture x86_64 --sanitizer address openjpeg ~/openjpeg```
The first time, it ran with an error message at the end about conformance.
The second time, it is producing an error ```mkdir: cannot create directory 'build': File exists```, but I do not know where this folder is to delete it.
I am happy to run fuzzing on this pull request.

Kind regards,
Aous.

PS: There is another small modification, unrelated to Chromium fuzzer, to some quantities to make them more meaningful, but let's get this thing through.



