### PR TITLE
Make OpenJPEGConfig.cmake relocatable with CMake > 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,12 +304,23 @@ if(BUILD_TESTING)
 endif()
 
 #-----------------------------------------------------------------------------
-# install all targets referenced as OPENJPEGTargets
+# install all targets referenced as OPENJPEGTargets (relocatable with CMake 3.0+)
 install(EXPORT OpenJPEGTargets DESTINATION ${OPENJPEG_INSTALL_PACKAGE_DIR})
-configure_file( ${${OPENJPEG_NAMESPACE}_SOURCE_DIR}/cmake/OpenJPEGConfig.cmake.in
-  ${${OPENJPEG_NAMESPACE}_BINARY_DIR}/OpenJPEGConfig.cmake
-  @ONLY
-)
+if (${CMAKE_VERSION} VERSION_LESS 3.0)
+  set(PACKAGE_INIT)
+  set(PACKAGE_CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+  configure_file( ${${OPENJPEG_NAMESPACE}_SOURCE_DIR}/cmake/OpenJPEGConfig.cmake.in
+    ${${OPENJPEG_NAMESPACE}_BINARY_DIR}/OpenJPEGConfig.cmake
+    @ONLY
+  )
+else()
+  include(CMakePackageConfigHelpers)
+  configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/OpenJPEGConfig.cmake.in
+    ${OPENJPEG_BINARY_DIR}/OpenJPEGConfig.cmake
+    INSTALL_DESTINATION ${OPENJPEG_INSTALL_PACKAGE_DIR}
+    PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
+endif()
+
 install( FILES ${OPENJPEG_BINARY_DIR}/OpenJPEGConfig.cmake
   DESTINATION ${OPENJPEG_INSTALL_PACKAGE_DIR}
 )

--- a/cmake/OpenJPEGConfig.cmake.in
+++ b/cmake/OpenJPEGConfig.cmake.in
@@ -5,6 +5,7 @@
 # This file is configured by OPENJPEG and used by the UseOPENJPEG.cmake
 # module to load OPENJPEG's settings for an external project.
 @OPENJPEG_CONFIG_INSTALL_ONLY@
+@PACKAGE_INIT@
 # The OPENJPEG version number.
 set(OPENJPEG_MAJOR_VERSION "@OPENJPEG_VERSION_MAJOR@")
 set(OPENJPEG_MINOR_VERSION "@OPENJPEG_VERSION_MINOR@")
@@ -27,7 +28,7 @@ if(EXISTS ${SELF_DIR}/OpenJPEGTargets.cmake)
   # This is an install tree
   include(${SELF_DIR}/OpenJPEGTargets.cmake)
 
-  set(INC_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@/@OPENJPEG_INSTALL_SUBDIR@")
+  set(INC_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/@OPENJPEG_INSTALL_SUBDIR@")
   get_filename_component(OPENJPEG_INCLUDE_DIRS "${INC_DIR}" ABSOLUTE)
 
 else()


### PR DESCRIPTION
Using CMakePackageConfigHelpers, we can generate a relocatable
OpenJPEGConfig.config, using the PATH_VARS feature to make
CMAKE_INSTALL_LIBDIR relative to the installed location.
This change is needed for me when cross-compiling since
CMAKE_INSTALL_FULL_LIBDIR is a path inside the sysroot rather than
an absolute path to the actual includes. Without this change poppler
ends up passing a -I flag that does not exist.

This includes fallback code for CMake 2.8, which adds a bit of complexity,
since I'm not sure if raising the minimum to 3.0 (now over 8 years old)
is acceptable.