### PR TITLE
Significant speed-up rate allocation by rate/distoratio ratio

### DIFF
--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -846,7 +846,7 @@ static int parse_cmdline_encoder(int argc, char **argv,
 
         /* ----------------------------------------------------- */
 
-        case 'q': {         /* add fixed_quality */
+        case 'q': {         /* layer allocation by distortion ratio (PSNR) */
             char *s = opj_optarg;
             while (sscanf(s, "%f", &parameters->tcp_distoratio[parameters->tcp_numlayers])
                     == 1) {
@@ -866,7 +866,7 @@ static int parse_cmdline_encoder(int argc, char **argv,
         /* dda */
         /* ----------------------------------------------------- */
 
-        case 'f': {         /* mod fixed_quality (before : -q) */
+        case 'f': {         /* layer allocation by fixed layer */
             int *row = NULL, *col = NULL;
             OPJ_UINT32 numlayers = 0, numresolution = 0, matrix_width = 0;
 
@@ -1812,7 +1812,7 @@ static int parse_cmdline_encoder(int argc, char **argv,
                   parameters->cp_fixed_quality))) {
         fprintf(stderr, "[ERROR] options -r -q and -f cannot be used together !!\n");
         return 1;
-    }               /* mod fixed_quality */
+    }
 
 
     /* if no rate entered, lossless by default */

--- a/src/lib/openjp2/bio.c
+++ b/src/lib/openjp2/bio.c
@@ -44,12 +44,6 @@
 /*@{*/
 
 /**
-Write a bit
-@param bio BIO handle
-@param b Bit to write (0 or 1)
-*/
-static void opj_bio_putbit(opj_bio_t *bio, OPJ_UINT32 b);
-/**
 Read a bit
 @param bio BIO handle
 @return Returns the read bit
@@ -98,16 +92,6 @@ static OPJ_BOOL opj_bio_bytein(opj_bio_t *bio)
     }
     bio->buf |= *bio->bp++;
     return OPJ_TRUE;
-}
-
-static void opj_bio_putbit(opj_bio_t *bio, OPJ_UINT32 b)
-{
-    if (bio->ct == 0) {
-        opj_bio_byteout(
-            bio); /* MSD: why not check the return value of this function ? */
-    }
-    bio->ct--;
-    bio->buf |= b << bio->ct;
 }
 
 static OPJ_UINT32 opj_bio_getbit(opj_bio_t *bio)
@@ -160,6 +144,16 @@ void opj_bio_init_dec(opj_bio_t *bio, OPJ_BYTE *bp, OPJ_UINT32 len)
     bio->bp = bp;
     bio->buf = 0;
     bio->ct = 0;
+}
+
+void opj_bio_putbit(opj_bio_t *bio, OPJ_UINT32 b)
+{
+    if (bio->ct == 0) {
+        opj_bio_byteout(
+            bio); /* MSD: why not check the return value of this function ? */
+    }
+    bio->ct--;
+    bio->buf |= b << bio->ct;
 }
 
 void opj_bio_write(opj_bio_t *bio, OPJ_UINT32 v, OPJ_UINT32 n)

--- a/src/lib/openjp2/bio.h
+++ b/src/lib/openjp2/bio.h
@@ -106,6 +106,14 @@ Write bits
 @param n Number of bits to write
 */
 void opj_bio_write(opj_bio_t *bio, OPJ_UINT32 v, OPJ_UINT32 n);
+
+/**
+Write a bit
+@param bio BIO handle
+@param b Bit to write (0 or 1)
+*/
+void opj_bio_putbit(opj_bio_t *bio, OPJ_UINT32 b);
+
 /**
 Read bits
 @param bio BIO handle

--- a/src/lib/openjp2/j2k.h
+++ b/src/lib/openjp2/j2k.h
@@ -113,6 +113,9 @@ The functions in J2K.C have for goal to read/write the several parts of the code
 
 #define J2K_MAX_POCS    32      /**< Maximum number of POCs */
 
+#define J2K_TCD_MATRIX_MAX_LAYER_COUNT 10
+#define J2K_TCD_MATRIX_MAX_RESOLUTION_COUNT 10
+
 /* ----------------------------------------------------------------------- */
 
 /**
@@ -272,7 +275,7 @@ typedef struct opj_tcp {
     OPJ_UINT32 ppt_data_size;
     /** size of ppt_data*/
     OPJ_UINT32 ppt_len;
-    /** add fixed_quality */
+    /** PSNR values */
     OPJ_FLOAT32 distoratio[100];
     /** tile-component coding parameters */
     opj_tccp_t *tccps;
@@ -314,6 +317,14 @@ typedef struct opj_tcp {
 } opj_tcp_t;
 
 
+/**
+Rate allocation strategy
+*/
+typedef enum {
+    RATE_DISTORTION_RATIO = 0,    /** allocation by rate/distortion */
+    FIXED_DISTORTION_RATIO = 1,   /** allocation by fixed distortion ratio (PSNR) (fixed quality) */
+    FIXED_LAYER = 2,              /** allocation by fixed layer (number of passes per layer / resolution / subband) */
+} J2K_QUALITY_LAYER_ALLOCATION_STRATEGY;
 
 
 typedef struct opj_encoding_param {
@@ -325,12 +336,8 @@ typedef struct opj_encoding_param {
     OPJ_INT32 *m_matrice;
     /** Flag determining tile part generation*/
     OPJ_BYTE m_tp_flag;
-    /** allocation by rate/distortion */
-    OPJ_BITFIELD m_disto_alloc : 1;
-    /** allocation by fixed layer */
-    OPJ_BITFIELD m_fixed_alloc : 1;
-    /** add fixed_quality */
-    OPJ_BITFIELD m_fixed_quality : 1;
+    /** Quality layer allocation strategy */
+    J2K_QUALITY_LAYER_ALLOCATION_STRATEGY m_quality_layer_alloc_strategy;
     /** Enabling Tile part generation*/
     OPJ_BITFIELD m_tp_on : 1;
 }

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -405,7 +405,7 @@ typedef struct opj_cparameters {
     int cp_disto_alloc;
     /** allocation by fixed layer */
     int cp_fixed_alloc;
-    /** add fixed_quality */
+    /** allocation by fixed quality (PSNR) */
     int cp_fixed_quality;
     /** fixed layer */
     int *cp_matrice;
@@ -829,9 +829,9 @@ typedef struct opj_tile_info {
     int pdy[33];
     /** information concerning packets inside tile */
     opj_packet_info_t *packet;
-    /** add fixed_quality */
+    /** number of pixels of the tile */
     int numpix;
-    /** add fixed_quality */
+    /** distortion of the tile */
     double distotile;
     /** number of markers */
     int marknum;

--- a/src/lib/openjp2/t1.c
+++ b/src/lib/openjp2/t1.c
@@ -1410,7 +1410,6 @@ static void opj_t1_dec_clnpass(
 }
 
 
-/** mod fixed_quality */
 static OPJ_FLOAT64 opj_t1_getwmsedec(
     OPJ_INT32 nmsedec,
     OPJ_UINT32 compno,
@@ -2313,7 +2312,7 @@ OPJ_BOOL opj_t1_encode_cblks(opj_tcd_t* tcd,
     OPJ_UINT32 compno, resno, bandno, precno, cblkno;
     opj_mutex_t* mutex = opj_mutex_create();
 
-    tile->distotile = 0;        /* fixed_quality */
+    tile->distotile = 0;
 
     for (compno = 0; compno < tile->numcomps; ++compno) {
         opj_tcd_tilecomp_t* tilec = &tile->comps[compno];
@@ -2401,7 +2400,6 @@ static int opj_t1_enc_is_term_pass(opj_tcd_cblk_enc_t* cblk,
 }
 
 
-/** mod fixed_quality */
 static OPJ_FLOAT64 opj_t1_encode_cblk(opj_t1_t *t1,
                                       opj_tcd_cblk_enc_t* cblk,
                                       OPJ_UINT32 orient,
@@ -2505,7 +2503,6 @@ static OPJ_FLOAT64 opj_t1_encode_cblk(opj_t1_t *t1,
             break;
         }
 
-        /* fixed_quality */
         tempwmsedec = opj_t1_getwmsedec(nmsedec, compno, level, orient, bpno, qmfbid,
                                         stepsize, numcomps, mct_norms, mct_numcomps) ;
         cumwmsedec += tempwmsedec;

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -167,9 +167,9 @@ static OPJ_BOOL opj_t2_init_seg(opj_tcd_cblk_dec_t* cblk,
 static void opj_t2_putcommacode(opj_bio_t *bio, OPJ_INT32 n)
 {
     while (--n >= 0) {
-        opj_bio_write(bio, 1, 1);
+        opj_bio_putbit(bio, 1);
     }
-    opj_bio_write(bio, 0, 1);
+    opj_bio_putbit(bio, 0);
 }
 
 static OPJ_UINT32 opj_t2_getcommacode(opj_bio_t *bio)
@@ -184,7 +184,7 @@ static OPJ_UINT32 opj_t2_getcommacode(opj_bio_t *bio)
 static void opj_t2_putnumpasses(opj_bio_t *bio, OPJ_UINT32 n)
 {
     if (n == 1) {
-        opj_bio_write(bio, 0, 1);
+        opj_bio_putbit(bio, 0);
     } else if (n == 2) {
         opj_bio_write(bio, 2, 2);
     } else if (n <= 5) {
@@ -801,7 +801,7 @@ static OPJ_BOOL opj_t2_encode_packet(OPJ_UINT32 tileno,
         }
     }
 #endif
-    opj_bio_write(bio, packet_empty ? 0 : 1, 1);           /* Empty header bit */
+    opj_bio_putbit(bio, packet_empty ? 0 : 1);           /* Empty header bit */
 
     /* Writing Packet header */
     band = res->bands;
@@ -849,7 +849,7 @@ static OPJ_BOOL opj_t2_encode_packet(OPJ_UINT32 tileno,
             if (!cblk->numpasses) {
                 opj_tgt_encode(bio, prc->incltree, cblkno, (OPJ_INT32)(layno + 1));
             } else {
-                opj_bio_write(bio, layer->numpasses != 0, 1);
+                opj_bio_putbit(bio, layer->numpasses != 0);
             }
 
             /* if cblk not included, go to the next cblk  */
@@ -978,7 +978,9 @@ static OPJ_BOOL opj_t2_encode_packet(OPJ_UINT32 tileno,
                 return OPJ_FALSE;
             }
 
-            memcpy(c, layer->data, layer->len);
+            if (p_t2_mode == FINAL_PASS) {
+                memcpy(c, layer->data, layer->len);
+            }
             cblk->numpasses += layer->numpasses;
             c += layer->len;
             length -= layer->len;

--- a/src/lib/openjp2/tcd.h
+++ b/src/lib/openjp2/tcd.h
@@ -369,23 +369,6 @@ OPJ_BOOL opj_tcd_init(opj_tcd_t *p_tcd,
 OPJ_BOOL opj_tcd_init_decode_tile(opj_tcd_t *p_tcd, OPJ_UINT32 p_tile_no,
                                   opj_event_mgr_t* p_manager);
 
-void opj_tcd_makelayer_fixed(opj_tcd_t *tcd, OPJ_UINT32 layno,
-                             OPJ_UINT32 final);
-
-void opj_tcd_rateallocate_fixed(opj_tcd_t *tcd);
-
-void opj_tcd_makelayer(opj_tcd_t *tcd,
-                       OPJ_UINT32 layno,
-                       OPJ_FLOAT64 thresh,
-                       OPJ_UINT32 final);
-
-OPJ_BOOL opj_tcd_rateallocate(opj_tcd_t *tcd,
-                              OPJ_BYTE *dest,
-                              OPJ_UINT32 * p_data_written,
-                              OPJ_UINT32 len,
-                              opj_codestream_info_t *cstr_info,
-                              opj_event_mgr_t *p_manager);
-
 /**
  * Gets the maximum tile size that will be taken by the tile once decoded.
  */

--- a/src/lib/openjp2/tcd.h
+++ b/src/lib/openjp2/tcd.h
@@ -222,8 +222,8 @@ typedef struct opj_tcd_tilecomp {
     OPJ_UINT32 win_x1;
     OPJ_UINT32 win_y1;
 
-    /* add fixed_quality */
-    OPJ_INT32 numpix;
+    /* number of pixels */
+    OPJ_SIZE_T numpix;
 } opj_tcd_tilecomp_t;
 
 
@@ -235,9 +235,9 @@ typedef struct opj_tcd_tile {
     OPJ_INT32 x0, y0, x1, y1;
     OPJ_UINT32 numcomps;            /* number of components in tile */
     opj_tcd_tilecomp_t *comps;  /* Components information */
-    OPJ_INT32 numpix;               /* add fixed_quality */
-    OPJ_FLOAT64 distotile;          /* add fixed_quality */
-    OPJ_FLOAT64 distolayer[100];    /* add fixed_quality */
+    OPJ_SIZE_T numpix;               /* number of pixels */
+    OPJ_FLOAT64 distotile;          /* distortion of the tile */
+    OPJ_FLOAT64 distolayer[100];    /* distortion per layer */
     OPJ_UINT32 packno;              /* packet number */
 } opj_tcd_tile_t;
 

--- a/src/lib/openjp2/tgt.c
+++ b/src/lib/openjp2/tgt.c
@@ -287,12 +287,12 @@ void opj_tgt_encode(opj_bio_t *bio, opj_tgt_tree_t *tree, OPJ_UINT32 leafno,
         while (low < threshold) {
             if (low >= node->value) {
                 if (!node->known) {
-                    opj_bio_write(bio, 1, 1);
+                    opj_bio_putbit(bio, 1);
                     node->known = 1;
                 }
                 break;
             }
-            opj_bio_write(bio, 0, 1);
+            opj_bio_putbit(bio, 0);
             ++low;
         }
 


### PR DESCRIPTION
- Avoid doing 128 iterations all the time, and stop when the threshold
  doesn't vary much
- Avoid calling costly opj_t2_encode_packets() repeatdly when bisecting the
  layer ratio if the truncation points haven't changed since the last
  iteration.

When used with the GDAL gdal_translate application to convert a 11977 x
8745 raster with data type UInt16 and 8 channels, the conversion time
to JPEG2000 with 20 quality layers using disto/rate allocation (
-co "IC=C8" -co "JPEG2000_DRIVER=JP2OPENJPEG" -co "PROFILE=NPJE_NUMERICALLY_LOSSLESS"
creation options of the GDAL NITF driver) goes from 5m56 wall clock
(8m20s total, 12 vCPUs) down to 1m16 wall clock (3m45 total).

to be compared to 34s wall clock (3m5 total) for single quality layer output.