### PR TITLE
CMake: error out on warnings for strict/missing prototypes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
   # set(CMAKE_C_FLAGS "-Wall -std=c99 ${CMAKE_C_FLAGS}") # FIXME: this setting prevented us from setting a coverage build.
   # Do not use ffast-math for all build, it would produce incorrect results, only set for release:
   set(OPENJPEG_LIBRARY_COMPILE_OPTIONS ${OPENJPEG_LIBRARY_COMPILE_OPTIONS} "$<$<CONFIG:Release>:-ffast-math>")
-  set(OPENJP2_COMPILE_OPTIONS ${OPENJP2_COMPILE_OPTIONS} "$<$<CONFIG:Release>:-ffast-math>" -Wall -Wextra -Wconversion -Wunused-parameter -Wdeclaration-after-statement -Werror=declaration-after-statement)
+  set(OPENJP2_COMPILE_OPTIONS ${OPENJP2_COMPILE_OPTIONS} "$<$<CONFIG:Release>:-ffast-math>" -Wall -Wextra -Wconversion -Wunused-parameter -Wdeclaration-after-statement -Werror=declaration-after-statement -Wstrict-prototypes -Werror=strict-prototypes -Wmissing-prototypes -Werror=missing-prototypes)
 endif()
 
 #-----------------------------------------------------------------------------

--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -1883,7 +1883,7 @@ static void info_callback(const char *msg, void *client_data)
     fprintf(stdout, "[INFO] %s", msg);
 }
 
-OPJ_FLOAT64 opj_clock(void)
+static OPJ_FLOAT64 opj_clock(void)
 {
 #ifdef _WIN32
     /* _WIN32: use QueryPerformance (very accurate) */

--- a/src/bin/jp2/opj_decompress.c
+++ b/src/bin/jp2/opj_decompress.c
@@ -988,7 +988,7 @@ int parse_DA_values(char* inArg, unsigned int *DA_x0, unsigned int *DA_y0,
     }
 }
 
-OPJ_FLOAT64 opj_clock(void)
+static OPJ_FLOAT64 opj_clock(void)
 {
 #ifdef _WIN32
     /* _WIN32: use QueryPerformance (very accurate) */

--- a/src/lib/openjp2/ht_dec.c
+++ b/src/lib/openjp2/ht_dec.c
@@ -1083,6 +1083,26 @@ static OPJ_BOOL opj_t1_allocate_buffers(
     return OPJ_TRUE;
 }
 
+/**
+Decode 1 HT code-block
+@param t1 T1 handle
+@param cblk Code-block coding parameters
+@param orient
+@param roishift Region of interest shifting value
+@param cblksty Code-block style
+@param p_manager the event manager
+@param p_manager_mutex mutex for the event manager
+@param check_pterm whether PTERM correct termination should be checked
+*/
+OPJ_BOOL opj_t1_ht_decode_cblk(opj_t1_t *t1,
+                               opj_tcd_cblk_dec_t* cblk,
+                               OPJ_UINT32 orient,
+                               OPJ_UINT32 roishift,
+                               OPJ_UINT32 cblksty,
+                               opj_event_mgr_t *p_manager,
+                               opj_mutex_t* p_manager_mutex,
+                               OPJ_BOOL check_pterm);
+
 //************************************************************************/
 /** @brief Decodes one codeblock, processing the cleanup, siginificance
   *         propagation, and magnitude refinement pass

--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -6726,7 +6726,7 @@ OPJ_BOOL opj_j2k_set_threads(opj_j2k_t *j2k, OPJ_UINT32 num_threads)
     return OPJ_FALSE;
 }
 
-static int opj_j2k_get_default_thread_count()
+static int opj_j2k_get_default_thread_count(void)
 {
     const char* num_threads_str = getenv("OPJ_NUM_THREADS");
     int num_cpus;

--- a/src/lib/openjp2/openjpeg.c
+++ b/src/lib/openjp2/openjpeg.c
@@ -144,6 +144,11 @@ static void opj_close_from_file(void* p_user_data)
 /* ---------------------------------------------------------------------- */
 #ifdef _WIN32
 #ifndef OPJ_STATIC
+
+/* declaration to avoid warning: no previous prototype for 'DllMain' */
+BOOL APIENTRY
+DllMain(HINSTANCE hModule, DWORD ul_reason_for_call, LPVOID lpReserved);
+
 BOOL APIENTRY
 DllMain(HINSTANCE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {

--- a/src/lib/openjp2/thread.c
+++ b/src/lib/openjp2/thread.c
@@ -221,7 +221,7 @@ struct opj_thread_t {
     HANDLE hThread;
 };
 
-unsigned int __stdcall opj_thread_callback_adapter(void *info)
+static unsigned int __stdcall opj_thread_callback_adapter(void *info)
 {
     opj_thread_t* thread = (opj_thread_t*) info;
     HANDLE hEvent = NULL;


### PR DESCRIPTION
And fix strict-prototypes/missing-prototypes warnings.