### PR TITLE
Set a threshold for allocated memory in the opj_malloc file

### DIFF
--- a/src/lib/openjp2/opj_malloc.c
+++ b/src/lib/openjp2/opj_malloc.c
@@ -197,6 +197,16 @@ void * opj_malloc(size_t size)
 }
 void * opj_calloc(size_t num, size_t size)
 {
+    static unsigned long long allocated_size = 0;
+    static unsigned long long max_allocated_size = 4ULL * 1024 * 1024 * 1024;
+    /*Restrict this function can only malloc 4GB of memory*/
+    
+    unsigned long long total_size = (unsigned long long)(num * size);
+    allocated_size += total_size;
+    if (allocated_size > max_allocated_size) {
+        /*Prevent excessive resource allocation*/
+        return NULL;
+    }
     if (num == 0 || size == 0) {
         /* prevent implementation defined behavior of realloc */
         return NULL;


### PR DESCRIPTION
When I was fuzzing, I found a file that can bypass all current error checks. This file can cause program denial of service, similar to cve-2019-6988. 

The poc is [here](https://github.com/pic4xiu/pocRep/blob/main/poc)

Run: `opj_decompress -i poc -o te.png`

I used gdb to debug and trace, and found that the program will call opj_calloc to open 2g of memory in each large loop, and this poc will cause the program to loop thousands of times. 

Perhaps it is more appropriate to introduce a new parameter to allow users to choose how many resources can be provided, but this will be an API change, and the impact will be great. So I directly introduced a variable for statistical memory in the function. In fact, similar functions can also be counted into variables, but because I have not observed a situation that can trigger similar bugs, so this commit does not add changes to other functions.