### PR TITLE
ht_dec.c: Improve MSVC arm64 popcount performance

### DIFF
--- a/src/lib/openjp2/ht_dec.c
+++ b/src/lib/openjp2/ht_dec.c
@@ -76,8 +76,8 @@ OPJ_UINT32 population_count(OPJ_UINT32 val)
 #if defined(OPJ_COMPILER_MSVC) && (defined(_M_IX86) || defined(_M_AMD64))
     return (OPJ_UINT32)__popcnt(val);
 #elif defined(OPJ_COMPILER_MSVC) && defined(_M_ARM64)
-    const __n64 _Temp = neon_cnt(__uint64ToN64_v(val));
-    return neon_addv8(_Temp).n8_i8[0];
+    const __n64 temp = neon_cnt(__uint64ToN64_v(val));
+    return neon_addv8(temp).n8_i8[0];
 #elif (defined OPJ_COMPILER_GNUC)
     return (OPJ_UINT32)__builtin_popcount(val);
 #else

--- a/src/lib/openjp2/ht_dec.c
+++ b/src/lib/openjp2/ht_dec.c
@@ -55,6 +55,10 @@
 #define OPJ_COMPILER_GNUC
 #endif
 
+#if defined(OPJ_COMPILER_MSVC) && defined(_M_ARM64)
+#include <arm64_neon.h>
+#endif
+
 //************************************************************************/
 /** @brief Displays the error message for disabling the decoding of SPP and
   * MRP passes
@@ -71,6 +75,9 @@ OPJ_UINT32 population_count(OPJ_UINT32 val)
 {
 #if defined(OPJ_COMPILER_MSVC) && (defined(_M_IX86) || defined(_M_AMD64))
     return (OPJ_UINT32)__popcnt(val);
+#elif defined(OPJ_COMPILER_MSVC) && defined(_M_ARM64)
+    const __n64 _Temp = neon_cnt(__uint64ToN64_v(val));
+    return neon_addv8(_Temp).n8_i8[0];
 #elif (defined OPJ_COMPILER_GNUC)
     return (OPJ_UINT32)__builtin_popcount(val);
 #else

--- a/src/lib/openjp2/ht_dec.c
+++ b/src/lib/openjp2/ht_dec.c
@@ -55,7 +55,13 @@
 #define OPJ_COMPILER_GNUC
 #endif
 
-#if defined(OPJ_COMPILER_MSVC) && defined(_M_ARM64)
+#if defined(OPJ_COMPILER_MSVC) && defined(_M_ARM64) \
+    && !defined(_M_ARM64EC) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
+    && !defined(__INTEL_COMPILER) && !defined(__clang__)
+#define MSVC_NEON_INTRINSICS
+#endif
+
+#ifdef MSVC_NEON_INTRINSICS
 #include <arm64_neon.h>
 #endif
 
@@ -75,7 +81,7 @@ OPJ_UINT32 population_count(OPJ_UINT32 val)
 {
 #if defined(OPJ_COMPILER_MSVC) && (defined(_M_IX86) || defined(_M_AMD64))
     return (OPJ_UINT32)__popcnt(val);
-#elif defined(OPJ_COMPILER_MSVC) && defined(_M_ARM64)
+#elif defined(OPJ_COMPILER_MSVC) && defined(MSVC_NEON_INTRINSICS)
     const __n64 temp = neon_cnt(__uint64ToN64_v(val));
     return neon_addv8(temp).n8_i8[0];
 #elif (defined OPJ_COMPILER_GNUC)


### PR DESCRIPTION
Use NEON instructions for ARM64 (implementation based on microsoft/STL#2127).

Godbolt output here: https://godbolt.org/z/q7GPTqT14