### PR TITLE
Integer Overflow at j2k.c:3962

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -3959,9 +3959,12 @@ static OPJ_BOOL opj_j2k_merge_ppm(opj_cp_t *p_cp, opj_event_mgr_t * p_manager)
                     opj_read_bytes(l_data, &l_N_ppm, 4);
                     l_data += 4;
                     l_data_size -= 4;
-                    l_ppm_data_size +=
-                        l_N_ppm; /* can't overflow, max 256 markers of max 65536 bytes, that is when PPM markers are not corrupted which is checked elsewhere */
 
+                    if (l_ppm_data_size > UINT_MAX - l_N_ppm) {
+                        opj_event_msg(p_manager, EVT_ERROR, "Too large value for Nppm\n");
+                        return OPJ_FALSE;
+                    }
+                    l_ppm_data_size += l_N_ppm;
                     if (l_data_size >= l_N_ppm) {
                         l_data_size -= l_N_ppm;
                         l_data += l_N_ppm;


### PR DESCRIPTION
Hi! We've been fuzzing openjpeg with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and we found integer overflow error in `j2k.c:3962`.

In function opj_j2k_merge_ppm at line 3962 integer overflow occurs in variable `l_ppm_data_size` (the value of `l_N_ppm` was 4294967295). Also there is a comment that says it can't overflow, but `l_N_ppm`  (returned from `opj_read_bytes`) turned out to be too big. So I've just added a checked for that overflow, but maybe it is also possible to check for its validity in `opj_read_byte`.

### Environment

- OS: ubuntu 20.04
- commit: 6af39314bdb43cb9c7adcdbc7aa9381af42b52ba

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/openjpeg):

    ```
    sudo docker build -t oss-sydr-fuzz-openjpeg .
    ```

2. Run docker container:

    ```
    sudo docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-openjpeg /bin/bash
    ```

3. Run on the following [input](https://github.com/uclouvain/openjpeg/files/13587364/sydr_j2k_data.txt):

    ```
     /opj_decompress_fuzzer_J2K_fuzz  sydr_j2k_data.txt
    ```
4. Output:

    ```
    /openjpeg/src/lib/openjp2/j2k.c:3962:37: runtime error: unsigned integer overflow: 1150 + 4294967295 cannot be represented in type 'unsigned int'
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /openjpeg/src/lib/openjp2/j2k.c:3962:37
    ```