### PR TITLE
fix ht_dec.c:1215

### DIFF
--- a/src/lib/openjp2/ht_dec.c
+++ b/src/lib/openjp2/ht_dec.c
@@ -1210,6 +1210,9 @@ OPJ_BOOL opj_t1_ht_decode_cblk(opj_t1_t *t1,
 
         /* Concatenate all chunks */
         cblkdata = t1->cblkdatabuffer;
+        if (cblkdata == NULL) {
+            return OPJ_FALSE;
+        }
         cblk_len = 0;
         for (i = 0; i < cblk->numchunks; i++) {
             memcpy(cblkdata + cblk_len, cblk->chunks[i].data, cblk->chunks[i].len);


### PR DESCRIPTION
Hi! We've been fuzzing openjpeg with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and we found incorrect using of `memcpy` in `ht_dec.c:1215`.

In function opj_t1_ht_decode_cblk at line 1215  there is a `memcpy` call: `memcpy(cblkdata + cblk_len, cblk->chunks[i].data, cblk->chunks[i].len)`. We have found input where `cblk_len` is NULL, so therefore nullptr + offset is put in destination parameter of `memcpy` and that is incorrect. Also, if `cblk_len` is NULL and cblk->chunks[i].len is not zero, that instantly leads to crash. 

### Environment

- OS: ubuntu 20.04
- commit: 6af39314bdb43cb9c7adcdbc7aa9381af42b52ba

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/openjpeg):

    ```
    sudo docker build -t oss-sydr-fuzz-openjpeg .
    ```

2. Run docker container:

    ```
    sudo docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-openjpeg /bin/bash
    ```

3. Run on the following [input](https://github.com/uclouvain/openjpeg/files/13587750/sydr_ht_dec.txt):

    ```
     /opj_decompress_fuzzer_JP2_afl sydr_ht_dec.txt
    ```
4. Output:

    ```
    /openjpeg/src/lib/openjp2/ht_dec.c:1215:20: runtime error: null pointer passed as argument 1, which is declared to never be null
    /usr/include/string.h:44:28: note: nonnull attribute specified here
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /openjpeg/src/lib/openjp2/ht_dec.c:1215:20
    ```