### PR TITLE
suppress warning during build using clang

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -7815,7 +7815,7 @@ OPJ_BOOL opj_j2k_setup_encoder(opj_j2k_t *p_j2k,
                                        image->comps[0].h * image->comps[0].prec) /
                                       ((double)parameters->tcp_rates[parameters->tcp_numlayers - 1] * 8 *
                                        image->comps[0].dx * image->comps[0].dy));
-            if (temp_size > INT_MAX) {
+            if (temp_size > (OPJ_FLOAT32)INT_MAX) {
                 parameters->max_cs_size = INT_MAX;
             } else {
                 parameters->max_cs_size = (int) floor(temp_size);

--- a/src/lib/openjp2/tcd.c
+++ b/src/lib/openjp2/tcd.c
@@ -2330,7 +2330,7 @@ static OPJ_BOOL opj_tcd_dc_level_shift_decode(opj_tcd_t *p_tcd)
             for (j = 0; j < l_height; ++j) {
                 for (i = 0; i < l_width; ++i) {
                     OPJ_FLOAT32 l_value = *((OPJ_FLOAT32 *) l_current_ptr);
-                    if (l_value > INT_MAX) {
+                    if (l_value > (OPJ_FLOAT32)INT_MAX) {
                         *l_current_ptr = l_max;
                     } else if (l_value < INT_MIN) {
                         *l_current_ptr = l_min;


### PR DESCRIPTION
I had a chance to build OpenCV with clang 10 and realized some warnings happening.
I created PR in OpenCV and now I'm porting to upstream.

```
/opencv/3rdparty/openjpeg/openjp2/j2k.c:7799:29: warning: implicit conversion from 'int' to 'float' changes value from 21
47483647 to 2147483648 [-Wimplicit-int-float-conversion]
            if (temp_size > INT_MAX) {
                          ~ ^~~~~~~
/usr/lib/llvm-10/lib/clang/10.0.0/include/limits.h:46:19: note: expanded from macro 'INT_MAX'
#define INT_MAX   __INT_MAX__
                  ^~~~~~~~~~~
<built-in>:37:21: note: expanded from here
#define __INT_MAX__ 2147483647
                    ^~~~~~~~~~
1 warning generated.
```

```
/opencv/3rdparty/openjpeg/openjp2/tcd.c:2265:35: warning: implicit conversion from 'int' to 'float' changes value from 21
47483647 to 2147483648 [-Wimplicit-int-float-conversion]
                    if (l_value > INT_MAX) {
                                ~ ^~~~~~~
/usr/lib/llvm-10/lib/clang/10.0.0/include/limits.h:46:19: note: expanded from macro 'INT_MAX'
#define INT_MAX   __INT_MAX__
                  ^~~~~~~~~~~
<built-in>:37:21: note: expanded from here
#define __INT_MAX__ 2147483647
                    ^~~~~~~~~~
1 warning generated.
```

It's just a warning of corner case, but I think it's worth preventing it.