### PR TITLE
Fix compiler error on Windows

### DIFF
--- a/src/lib/openjp2/openjpeg.c
+++ b/src/lib/openjp2/openjpeg.c
@@ -438,7 +438,7 @@ OPJ_BOOL OPJ_CALLCONV opj_setup_decoder(opj_codec_t *p_codec,
     return OPJ_FALSE;
 }
 
-OPJ_API OPJ_BOOL OPJ_CALLCONV opj_decoder_set_strict_mode(opj_codec_t *p_codec,
+OPJ_BOOL OPJ_CALLCONV opj_decoder_set_strict_mode(opj_codec_t *p_codec,
         OPJ_BOOL strict)
 {
     if (p_codec) {


### PR DESCRIPTION
Fix for a compilation error with `MSVC/14.37.32822/bin/HostX64/x64/cl.exe`:

```
openjpeg\src\lib\openjp2\openjpeg.c(438): error C2491: 'opj_decoder_set_strict_mode': definition of dllimport function not allowed
```