### PR TITLE
CMake: drop support for cmake < 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,7 @@
 # For this purpose you can define a CMake var: OPENJPEG_NAMESPACE to whatever you like
 # e.g.:
 # set(OPENJPEG_NAMESPACE "GDCMOPENJPEG")
-cmake_minimum_required(VERSION 2.8.5)
-
-if(COMMAND CMAKE_POLICY)
-  cmake_policy(SET CMP0003 NEW)
-  if (NOT (${CMAKE_VERSION} VERSION_LESS 3.0))
-    cmake_policy(SET CMP0042 NEW)
-  endif()
-endif()
+cmake_minimum_required(VERSION 3.5)
 
 if(NOT OPENJPEG_NAMESPACE)
   set(OPENJPEG_NAMESPACE "OPENJPEG")
@@ -126,12 +119,6 @@ if(NOT OPENJPEG_INSTALL_PACKAGE_DIR)
 endif()
 
 if (APPLE)
-    if (${CMAKE_VERSION} VERSION_LESS 3.0)
-        # For cmake >= 3.0, we turn on CMP0042 and
-        # https://cmake.org/cmake/help/v3.0/policy/CMP0042.html mentions
-        # "Projects wanting @rpath in a target’s install name may remove any setting of the INSTALL_NAME_DIR and CMAKE_INSTALL_NAME_DIR variables"
-	list(APPEND OPENJPEG_LIBRARY_PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
-    endif()
 	option(OPJ_USE_DSYMUTIL "Call dsymutil on binaries after build." OFF)
 endif()
 
@@ -304,21 +291,11 @@ endif()
 #-----------------------------------------------------------------------------
 # install all targets referenced as OPENJPEGTargets (relocatable with CMake 3.0+)
 install(EXPORT OpenJPEGTargets DESTINATION ${OPENJPEG_INSTALL_PACKAGE_DIR})
-if (${CMAKE_VERSION} VERSION_LESS 3.0)
-  set(PACKAGE_INIT)
-  set(PACKAGE_CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_FULL_INCLUDEDIR})
-  configure_file( ${${OPENJPEG_NAMESPACE}_SOURCE_DIR}/cmake/OpenJPEGConfig.cmake.in
-    ${${OPENJPEG_NAMESPACE}_BINARY_DIR}/OpenJPEGConfig.cmake
-    @ONLY
-  )
-else()
-  include(CMakePackageConfigHelpers)
-  configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/OpenJPEGConfig.cmake.in
-    ${OPENJPEG_BINARY_DIR}/OpenJPEGConfig.cmake
-    INSTALL_DESTINATION ${OPENJPEG_INSTALL_PACKAGE_DIR}
-    PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
-endif()
-
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/OpenJPEGConfig.cmake.in
+  ${OPENJPEG_BINARY_DIR}/OpenJPEGConfig.cmake
+  INSTALL_DESTINATION ${OPENJPEG_INSTALL_PACKAGE_DIR}
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
 install( FILES ${OPENJPEG_BINARY_DIR}/OpenJPEGConfig.cmake
   DESTINATION ${OPENJPEG_INSTALL_PACKAGE_DIR}
 )

--- a/src/bin/jp2/CMakeLists.txt
+++ b/src/bin/jp2/CMakeLists.txt
@@ -44,9 +44,7 @@ endif()
 # Loop over all executables:
 foreach(exe opj_decompress opj_compress opj_dump)
   add_executable(${exe} ${exe}.c ${common_SRCS})
-  if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12")
-    target_compile_options(${exe} PRIVATE ${OPENJP2_COMPILE_OPTIONS})
-  endif()
+  target_compile_options(${exe} PRIVATE ${OPENJP2_COMPILE_OPTIONS})
   target_link_libraries(${exe} ${OPENJPEG_LIBRARY_NAME}
     ${PNG_LIBNAME} ${TIFF_LIBNAME} ${LCMS_LIBNAME}
     )

--- a/src/lib/openjp2/CMakeLists.txt
+++ b/src/lib/openjp2/CMakeLists.txt
@@ -109,9 +109,7 @@ if(UNIX)
   target_link_libraries(${OPENJPEG_LIBRARY_NAME} m)
 endif()
 set_target_properties(${OPENJPEG_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
-if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12")
-  target_compile_options(${OPENJPEG_LIBRARY_NAME} PRIVATE ${OPENJP2_COMPILE_OPTIONS})
-endif()
+target_compile_options(${OPENJPEG_LIBRARY_NAME} PRIVATE ${OPENJP2_COMPILE_OPTIONS})
 
 # Install library
 install(TARGETS ${INSTALL_LIBS}

--- a/src/lib/openjpip/CMakeLists.txt
+++ b/src/lib/openjpip/CMakeLists.txt
@@ -62,9 +62,7 @@ endif()
 add_library(openjpip ${OPENJPIP_SRCS} ${LOCAL_SRCS})
 set_target_properties(openjpip
   PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
-if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12")
-  target_compile_options(openjpip PRIVATE ${OPENJPEG_LIBRARY_COMPILE_OPTIONS})
-endif()
+target_compile_options(openjpip PRIVATE ${OPENJPEG_LIBRARY_COMPILE_OPTIONS})
 target_link_libraries(openjpip ${OPENJPEG_LIBRARY_NAME})
 if(WIN32)
   # add Winsock on windows+mingw

--- a/tests/nonregression/CMakeLists.txt
+++ b/tests/nonregression/CMakeLists.txt
@@ -1,6 +1,6 @@
 # NON-REGRESSION TESTS ON THIS DATASET LOCATED ${OPJ_DATA_ROOT}/input/nonregression
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.5)
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Temporary)
 

--- a/tools/ctest_scripts/travis-ci.cmake
+++ b/tools/ctest_scripts/travis-ci.cmake
@@ -4,7 +4,7 @@
 # Results will be available at: http://my.cdash.org/index.php?project=OPENJPEG
 # -----------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 set( ENV{LANG} en_US.UTF-8)
 if($ENV{OPJ_BINARY_DIR})


### PR DESCRIPTION
Compatibility for cmake version < 3.5 is now deprecated in cmake and specifying version below 3.5 in cmake_minimum_required produces a warning.[1]

[1] https://cmake.org/cmake/help/latest/release/3.27.html#deprecated-and-removed-features