### PR TITLE
openjpeg.h: make sure to include opj_config.h (fixes #1514)

### DIFF
--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -138,6 +138,8 @@ typedef int64_t  OPJ_OFF_T; /* 64-bit file offset type */
 #include <stdio.h>
 typedef size_t   OPJ_SIZE_T;
 
+#include "opj_config.h"
+
 /* Avoid compile-time warning because parameter is not used */
 #define OPJ_ARG_NOT_USED(x) (void)(x)
 

--- a/src/lib/openjp2/opj_config.h.cmake.in
+++ b/src/lib/openjp2/opj_config.h.cmake.in
@@ -1,3 +1,6 @@
+#ifndef OPJ_CONFIG_H_INCLUDED
+#define OPJ_CONFIG_H_INCLUDED
+
 /* create opj_config.h for CMake */
 
 /*--------------------------------------------------------------------------*/
@@ -7,3 +10,5 @@
 #define OPJ_VERSION_MAJOR @OPENJPEG_VERSION_MAJOR@
 #define OPJ_VERSION_MINOR @OPENJPEG_VERSION_MINOR@
 #define OPJ_VERSION_BUILD @OPENJPEG_VERSION_BUILD@
+
+#endif


### PR DESCRIPTION
It was previously included by openjpeg.h