### PR TITLE
Do not allow header length to be zero in non-zero length packet

### DIFF
--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1353,6 +1353,9 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
 
     l_header_length = (OPJ_UINT32)(l_header_data - *l_header_data_start);
     JAS_FPRINTF(stderr, "hdrlen=%d \n", l_header_length);
+    if (!l_header_length) {
+        return OPJ_FALSE;
+    }
     JAS_FPRINTF(stderr, "packet body\n");
     *l_modified_length_ptr -= l_header_length;
     *l_header_data_start += l_header_length;


### PR DESCRIPTION
Resolves #1524

Investigating the file attached to that issue, I found that at
https://github.com/uclouvain/openjpeg/blob/e8b9d9274a0aee998402d967f65dadd919c31eca/src/lib/openjp2/t2.c#L1354
the header length was sometimes set to zero.

It seems intuitively not good for the header length to be zero in non-zero length packet, so I suggest returning `OPJ_FALSE` for that situation.

If this isn't a good solution, thanks for your time, and please let me know what I've missed.