### PR TITLE
Support setting enumcs for CMYK and EYCC color space

### DIFF
--- a/src/lib/openjp2/jp2.c
+++ b/src/lib/openjp2/jp2.c
@@ -1995,6 +1995,10 @@ OPJ_BOOL opj_jp2_setup_encoder(opj_jp2_t *jp2,
             jp2->enumcs = 17;    /* greyscale */
         } else if (image->color_space == 3) {
             jp2->enumcs = 18;    /* YUV */
+        } else if (image->color_space == 4) {
+            jp2->enumcs = 24;    /* EYCC */
+        } else if (image->color_space == 5) {
+            jp2->enumcs = 12;    /* CMYK */
         }
     }
 

--- a/src/lib/openjp2/jp2.c
+++ b/src/lib/openjp2/jp2.c
@@ -1989,16 +1989,16 @@ OPJ_BOOL opj_jp2_setup_encoder(opj_jp2_t *jp2,
         jp2->enumcs = 0;
     } else {
         jp2->meth = 1;
-        if (image->color_space == 1) {
+        if (image->color_space == OPJ_CLRSPC_SRGB) {
             jp2->enumcs = 16;    /* sRGB as defined by IEC 61966-2-1 */
-        } else if (image->color_space == 2) {
-            jp2->enumcs = 17;    /* greyscale */
-        } else if (image->color_space == 3) {
+        } else if (image->color_space == OPJ_CLRSPC_GRAY) {
+            jp2->enumcs = 17;
+        } else if (image->color_space == OPJ_CLRSPC_SYCC) {
             jp2->enumcs = 18;    /* YUV */
-        } else if (image->color_space == 4) {
-            jp2->enumcs = 24;    /* EYCC */
-        } else if (image->color_space == 5) {
-            jp2->enumcs = 12;    /* CMYK */
+        } else if (image->color_space == OPJ_CLRSPC_EYCC) {
+            jp2->enumcs = 24;
+        } else if (image->color_space == OPJ_CLRSPC_CMYK) {
+            jp2->enumcs = 12;
         }
     }
 


### PR DESCRIPTION
As per
https://github.com/uclouvain/openjpeg/blob/70e6263705334f854a27340e34ede11a767918ed/src/lib/openjp2/jp2.c#L2874-L2884
adds CMYK and EYCC to
https://github.com/uclouvain/openjpeg/blob/70e6263705334f854a27340e34ede11a767918ed/src/lib/openjp2/jp2.c#L1992-L1998