### PR TITLE
Integer Overflow at j2k.c:9614

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -9612,7 +9612,8 @@ OPJ_BOOL opj_j2k_read_tile_header(opj_j2k_t * p_j2k,
             /* Why this condition? FIXME */
             if (p_j2k->m_specific_param.m_decoder.m_state & J2K_STATE_TPH) {
                 if (p_j2k->m_specific_param.m_decoder.m_sot_length < l_marker_size + 2) {
-                    opj_event_msg(p_manager, EVT_ERROR, "Sot length is less than marker size + marker ID\n");
+                    opj_event_msg(p_manager, EVT_ERROR,
+                                  "Sot length is less than marker size + marker ID\n");
                     return OPJ_FALSE;
                 }
                 p_j2k->m_specific_param.m_decoder.m_sot_length -= (l_marker_size + 2);

--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -9611,6 +9611,10 @@ OPJ_BOOL opj_j2k_read_tile_header(opj_j2k_t * p_j2k,
 
             /* Why this condition? FIXME */
             if (p_j2k->m_specific_param.m_decoder.m_state & J2K_STATE_TPH) {
+                if (p_j2k->m_specific_param.m_decoder.m_sot_length < l_marker_size + 2) {
+                    opj_event_msg(p_manager, EVT_ERROR, "Sot length is less than marker size + marker ID\n");
+                    return OPJ_FALSE;
+                }
                 p_j2k->m_specific_param.m_decoder.m_sot_length -= (l_marker_size + 2);
             }
             l_marker_size -= 2; /* Subtract the size of the marker ID already read */


### PR DESCRIPTION
Hi! I've been fuzzing openjpeg with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and I found integer overflow error in `j2k.c:9614`.

In function `opj_j2k_read_tile_header` at line 9614 integer overflow occurs when value `l_marker_size + 2` is subtracted from variable `p_j2k->m_specific_param.m_decoder.m_sot_length` and value from this variable is less than `l_marker_size + 2`. So here i decided just to add a checker for valid data.

### Environment

- OS: ubuntu 20.04
- commit: 70e6263705334f854a27340e34ede11a767918ed

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/openjpeg):

    ```
    sudo docker build -t oss-sydr-fuzz-openjpeg .
    ```

2. Run docker container:

    ```
    sudo docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-openjpeg /bin/bash
    ```

3. Run on the following [input](https://github.com/user-attachments/files/15515815/sydr_j2k.txt):

    ```
     /opj_decompress_fuzzer_JP2_fuzz sydr_j2k.txt
    ```
4. Output:

    ```
    /home/ubuntu/headshog/openjpeg_build/openjpeg/src/lib/openjp2/j2k.c:9614:64: runtime error: unsigned integer overflow: 147 - 149 cannot be represented in type 'unsigned int'
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/ubuntu/headshog/openjpeg_build/openjpeg/src/lib/openjp2/j2k.c:9614:64
    ```