### PR TITLE
Avoid heap-buffer-overflow read on corrupted image in non-strict mode

### DIFF
--- a/src/lib/openjp2/t1.c
+++ b/src/lib/openjp2/t1.c
@@ -2006,10 +2006,16 @@ static OPJ_BOOL opj_t1_decode_cblk(opj_t1_t *t1,
     opj_mqc_setstate(mqc, T1_CTXNO_AGG, 0, 3);
     opj_mqc_setstate(mqc, T1_CTXNO_ZC, 0, 4);
 
+    if (cblk->corrupted) {
+        assert(cblk->numchunks == 0);
+        return OPJ_TRUE;
+    }
+
     /* Even if we have a single chunk, in multi-threaded decoding */
     /* the insertion of our synthetic marker might potentially override */
     /* valid codestream of other codeblocks decoded in parallel. */
-    if (cblk->numchunks > 1 || t1->mustuse_cblkdatabuffer) {
+    if (cblk->numchunks > 1 || (t1->mustuse_cblkdatabuffer &&
+                                cblk->numchunks > 0)) {
         OPJ_UINT32 i;
         OPJ_UINT32 cblk_len;
 

--- a/src/lib/openjp2/tcd.h
+++ b/src/lib/openjp2/tcd.h
@@ -141,6 +141,7 @@ typedef struct opj_tcd_cblk_dec {
     OPJ_UINT32 numchunksalloc;      /* Number of chunks item allocated */
     /* Decoded code-block. Only used for subtile decoding. Otherwise tilec->data is directly updated */
     OPJ_INT32* decoded_data;
+    OPJ_BOOL corrupted; /* whether the code block data is corrupted */
 } opj_tcd_cblk_dec_t;
 
 /** Precinct structure */


### PR DESCRIPTION
Fixes #1535