### PR TITLE
fix: when EPH markers are specified, they are required.

### DIFF
--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1111,6 +1111,7 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
     /* SOP markers */
 
     if (p_tcp->csty & J2K_CP_CSTY_SOP) {
+        /* SOP markers are allowed (i.e. optional), just warn */
         if (p_max_length < 6) {
             opj_event_msg(p_manager, EVT_WARNING,
                           "Not enough space for expected SOP marker\n");
@@ -1163,12 +1164,15 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
 
         /* EPH markers */
         if (p_tcp->csty & J2K_CP_CSTY_EPH) {
+            /* EPH markers are required */
             if ((*l_modified_length_ptr - (OPJ_UINT32)(l_header_data -
                     *l_header_data_start)) < 2U) {
-                opj_event_msg(p_manager, EVT_WARNING,
-                              "Not enough space for expected EPH marker\n");
+                opj_event_msg(p_manager, EVT_ERROR,
+                              "Not enough space for required EPH marker\n");
+                return OPJ_FALSE;
             } else if ((*l_header_data) != 0xff || (*(l_header_data + 1) != 0x92)) {
-                opj_event_msg(p_manager, EVT_WARNING, "Expected EPH marker\n");
+                opj_event_msg(p_manager, EVT_ERROR, "Expected EPH marker\n");
+                return OPJ_FALSE;
             } else {
                 l_header_data += 2;
             }
@@ -1340,12 +1344,15 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
 
     /* EPH markers */
     if (p_tcp->csty & J2K_CP_CSTY_EPH) {
+        /* EPH markers are required */
         if ((*l_modified_length_ptr - (OPJ_UINT32)(l_header_data -
                 *l_header_data_start)) < 2U) {
-            opj_event_msg(p_manager, EVT_WARNING,
-                          "Not enough space for expected EPH marker\n");
+            opj_event_msg(p_manager, EVT_ERROR,
+                          "Not enough space for required EPH marker\n");
+            return OPJ_FALSE;
         } else if ((*l_header_data) != 0xff || (*(l_header_data + 1) != 0x92)) {
-            opj_event_msg(p_manager, EVT_WARNING, "Expected EPH marker\n");
+            opj_event_msg(p_manager, EVT_ERROR, "Expected EPH marker\n");
+            return OPJ_FALSE;
         } else {
             l_header_data += 2;
         }

--- a/tests/nonregression/test_suite.ctest.in
+++ b/tests/nonregression/test_suite.ctest.in
@@ -669,3 +669,6 @@ opj_decompress -t 1 -i @INPUT_NR_PATH@/small_world_non_consecutive_tilepart_tlm.
 # decompress a subset of tiles, where tile-parts are not consecutive, and with a TLM index
 opj_decompress -i @INPUT_NR_PATH@/small_world_non_consecutive_tilepart_tlm.jp2 -o @TEMP_PATH@/small_world_non_consecutive_tilepart_tlm-t0-d.png -d 0,0,256,200
 opj_decompress -i @INPUT_NR_PATH@/small_world_non_consecutive_tilepart_tlm.jp2 -o @TEMP_PATH@/small_world_non_consecutive_tilepart_tlm-t1-d.png -d 256,0,400,200
+
+# missing EPH Marker
+!opj_decompress -i @INPUT_NR_PATH@/issue1472-bigloop.j2k -o @TEMP_PATH@/issue1472-bigloop.raw


### PR DESCRIPTION
reference from Rec. ITU-T T.800 (06/2019):
- Table A.13 – Coding style parameter values for the Scod parameter
- Section A.8.1 Start of packet (SOP)
- Section A.8.2 End of packet header (EPH)

mitigates #1472 (this just mitigates the exact PoC provided in #1472 but clearing the EPH presence from csty allows to see the behavior mentioned in #1472 again)

requires  https://github.com/uclouvain/openjpeg-data/pull/25