### PR TITLE
Do not turn on 'TPsot==TNsot detection fix' when TNsot==1, and 

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -6752,9 +6752,6 @@ void opj_j2k_setup_decoder(opj_j2k_t *j2k, opj_dparameters_t *parameters)
         j2k->m_cp.m_specific_param.m_dec.m_reduce = parameters->cp_reduce;
 
         j2k->dump_state = (parameters->flags & OPJ_DPARAMETERS_DUMP_FLAG);
-        if (parameters->flags & OPJ_DPARAMETERS_DISABLE_TPSOT_FIX) {
-            j2k->m_specific_param.m_decoder.m_nb_tile_parts_correction_checked = 1;
-        }
 #ifdef USE_JPWL
         j2k->m_cp.correct = parameters->jpwl_correct;
         j2k->m_cp.exp_comps = parameters->jpwl_exp_comps;
@@ -6767,6 +6764,9 @@ void opj_j2k_decoder_set_strict_mode(opj_j2k_t *j2k, OPJ_BOOL strict)
 {
     if (j2k) {
         j2k->m_cp.strict = strict;
+        if (strict) {
+            j2k->m_specific_param.m_decoder.m_nb_tile_parts_correction_checked = 1;
+        }
     }
 }
 

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -546,7 +546,12 @@ typedef struct opj_cparameters {
 } opj_cparameters_t;
 
 #define OPJ_DPARAMETERS_IGNORE_PCLR_CMAP_CDEF_FLAG  0x0001
-#define OPJ_DPARAMETERS_DUMP_FLAG 0x0002
+#define OPJ_DPARAMETERS_DUMP_FLAG                   0x0002
+
+/** Disable at runtime the check for invalid TPSOT values added in
+ * https://github.com/uclouvain/openjpeg/pull/514.
+ */
+#define OPJ_DPARAMETERS_DISABLE_TPSOT_FIX           0x0004
 
 /**
  * Decompression parameters

--- a/src/lib/openjp2/openjpeg.h
+++ b/src/lib/openjp2/openjpeg.h
@@ -548,11 +548,6 @@ typedef struct opj_cparameters {
 #define OPJ_DPARAMETERS_IGNORE_PCLR_CMAP_CDEF_FLAG  0x0001
 #define OPJ_DPARAMETERS_DUMP_FLAG                   0x0002
 
-/** Disable at runtime the check for invalid TPSOT values added in
- * https://github.com/uclouvain/openjpeg/pull/514.
- */
-#define OPJ_DPARAMETERS_DISABLE_TPSOT_FIX           0x0004
-
 /**
  * Decompression parameters
  * */
@@ -1353,9 +1348,13 @@ OPJ_API OPJ_BOOL OPJ_CALLCONV opj_setup_decoder(opj_codec_t *p_codec,
         opj_dparameters_t *parameters);
 
 /**
- * Set strict decoding parameter for this decoder.  If strict decoding is enabled, partial bit
- * streams will fail to decode.  If strict decoding is disabled, the decoder will decode partial
- * bitstreams as much as possible without erroring
+ * Set strict decoding parameter for this decoder.
+ * If strict decoding is enabled, partial bit streams will fail to decode, and
+ * the check for invalid TPSOT values added in https://github.com/uclouvain/openjpeg/pull/514
+ * will be disabled.
+ * If strict decoding is disabled, the decoder will decode partial
+ * bitstreams as much as possible without erroring, and the TPSOT fixing logic
+ * will be enabled.
  *
  * @param p_codec       decompressor handler
  * @param strict        OPJ_TRUE to enable strict decoding, OPJ_FALSE to disable


### PR DESCRIPTION
make opj_decoder_set_strict_mode(, true) to disable it too

Adresses the use case of https://lists.osgeo.org/pipermail/gdal-dev/2024-November/059805.html where Sentinel2 L1C JPEG2000 files are made of a single tile-part per tile.

Ammends https://github.com/uclouvain/openjpeg/pull/514