### PR TITLE
Amend fix of PR 1530 regarding m_sot_length check

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -9792,7 +9792,8 @@ OPJ_BOOL opj_j2k_read_tile_header(opj_j2k_t * p_j2k,
             }
 
             /* Why this condition? FIXME */
-            if (p_j2k->m_specific_param.m_decoder.m_state & J2K_STATE_TPH) {
+            if ((p_j2k->m_specific_param.m_decoder.m_state & J2K_STATE_TPH) &&
+                    p_j2k->m_specific_param.m_decoder.m_sot_length != 0) {
                 if (p_j2k->m_specific_param.m_decoder.m_sot_length < l_marker_size + 2) {
                     opj_event_msg(p_manager, EVT_ERROR,
                                   "Sot length is less than marker size + marker ID\n");


### PR DESCRIPTION
The fix of 2c0823cb30a70319c704565b59f496e490a3c7f9 (#1530) broke decoding of some JPEG2000 files where Isot==0, Psot==0, TPsot==0 and TNsot==0 like the following ones from the GDAL autotest suite: autotest/gdrivers/data/jpeg2000/stefan_full_rgba_alpha_1bit.jp2 autotest/gdrivers/data/jpeg2000/3_13bit_and_1bit.jp2