### PR TITLE
Build: compile source files in parallel under MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,10 @@ if(CMAKE_COMPILER_IS_GNUCC)
   set(OPENJPEG_LIBRARY_COMPILE_OPTIONS ${OPENJPEG_LIBRARY_COMPILE_OPTIONS} "$<$<CONFIG:Release>:-ffast-math>")
   set(OPENJP2_COMPILE_OPTIONS ${OPENJP2_COMPILE_OPTIONS} "$<$<CONFIG:Release>:-ffast-math>" -Wall -Wextra -Wconversion -Wunused-parameter -Wdeclaration-after-statement -Werror=declaration-after-statement -Wstrict-prototypes -Werror=strict-prototypes -Wmissing-prototypes -Werror=missing-prototypes)
 endif()
+if(MSVC)
+  # Parallel source file compilation in MSVC
+  set(OPENJP2_COMPILE_OPTIONS ${OPENJP2_COMPILE_OPTIONS} "/MP")
+endif()
 
 #-----------------------------------------------------------------------------
 # opj_config.h generation (1/2)


### PR DESCRIPTION
When using cmake with Visual Studio project files (default on Windows), add MSVC compile flag that enables using more than 1 CPU core during the build (i.e. compile source files in parallel).

On my PC (Ryzen 5950X), full rebuild of the MSVC solution in Release config goes from 4.6sec down to 2.4sec. Not much, but there's no downside of using the `/MP` flag. (I've recently landed the same build improvement in [OpenEXR](https://github.com/AcademySoftwareFoundation/openexr/pull/1858) and [OpenColorIO](https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/2072))