### PR TITLE
opj_jp2_read_header: Check for error after parsing header.

### DIFF
--- a/src/lib/openjp2/jp2.c
+++ b/src/lib/openjp2/jp2.c
@@ -2873,7 +2873,7 @@ OPJ_BOOL opj_jp2_read_header(opj_stream_private_t *p_stream,
                               p_image,
                               p_manager);
 
-    if (p_image && *p_image) {
+    if (ret && p_image && *p_image) {
         /* Set Image Color Space */
         if (jp2->enumcs == 16) {
             (*p_image)->color_space = OPJ_CLRSPC_SRGB;


### PR DESCRIPTION
Consider the case where the caller has not set the p_image pointer to NULL before calling opj_read_header().

If opj_j2k_read_header_procedure() fails while obtaining the rest of the marker segment when calling opj_stream_read_data() because the data stream is too short, then opj_j2k_read_header() will never have the chance to initialize p_image, leaving it uninitialized.

opj_jp2_read_header() will check the p_image value whether opj_j2k_read_header() suceeded or failed. This may be detected as an error in valgrind or ASAN.

The fix is to check whether opj_j2k_read_header() suceeded before using the output argument p_image.