### PR TITLE
Fixed ICC profile copy failure on write

### DIFF
--- a/src/lib/openjp2/jp2.c
+++ b/src/lib/openjp2/jp2.c
@@ -1990,7 +1990,8 @@ OPJ_BOOL opj_jp2_setup_encoder(opj_jp2_t *jp2,
         jp2->color.icc_profile_buf = (OPJ_BYTE *)opj_malloc(image->icc_profile_len);
         if (jp2->color.icc_profile_buf) {
             jp2->color.icc_profile_len = image->icc_profile_len;
-            memcpy(jp2->color.icc_profile_buf, image->icc_profile_buf, image->icc_profile_len);
+            memcpy(jp2->color.icc_profile_buf, image->icc_profile_buf,
+                   image->icc_profile_len);
         }
     } else {
         jp2->meth = 1;

--- a/src/lib/openjp2/jp2.c
+++ b/src/lib/openjp2/jp2.c
@@ -1987,6 +1987,11 @@ OPJ_BOOL opj_jp2_setup_encoder(opj_jp2_t *jp2,
     if (image->icc_profile_len) {
         jp2->meth = 2;
         jp2->enumcs = 0;
+        jp2->color.icc_profile_buf = (OPJ_BYTE *)opj_malloc(image->icc_profile_len);
+        if (jp2->color.icc_profile_buf) {
+            jp2->color.icc_profile_len = image->icc_profile_len;
+            memcpy(jp2->color.icc_profile_buf, image->icc_profile_buf, image->icc_profile_len);
+        }
     } else {
         jp2->meth = 1;
         if (image->color_space == OPJ_CLRSPC_SRGB) {


### PR DESCRIPTION
When I set a color profile in write I always get an assert in `opj_jp2_write_colr()` (line 831). I've been using the library for a short time, but I didn't find any other way to pass the profile on write. Looking at the code it seems that the color profile set in the image is never copied to `jp2->color`.
