### PR TITLE
pkgconfig: drop unused libraries from `Libs.private`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,19 @@ set_variable_from_rel_or_absolute_path("docdir" "\\\${prefix}" "${CMAKE_INSTALL_
 set_variable_from_rel_or_absolute_path("libdir" "\\\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
 set_variable_from_rel_or_absolute_path("includedir" "\\\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}/${OPENJPEG_INSTALL_SUBDIR}")
 
+function(get_pkgconfig_deps NAME OUT)
+  get_target_property(link_libs ${NAME} LINK_LIBRARIES)
+  if(NOT link_libs STREQUAL "link_libs-NOTFOUND")
+    foreach(lib ${link_libs})
+      # omit -lopenjp2 from Libs.private because libopenjp2 is in Requires
+      if(NOT ${lib} STREQUAL ${OPENJPEG_LIBRARY_NAME})
+        string(APPEND deps "-l${lib} ")
+      endif()
+    endforeach()
+  endif()
+  set(${OUT} ${deps} PARENT_SCOPE)
+endfunction()
+get_pkgconfig_deps(${OPENJPEG_LIBRARY_NAME} deps)
 # install in lib and not share (CMAKE_INSTALL_LIBDIR takes care of it for multi-arch)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/lib/openjp2/libopenjp2.pc.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/libopenjp2.pc @ONLY)
@@ -335,6 +348,7 @@ install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libopenjp2.pc DESTINATION
   ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 #
 if(BUILD_JPIP)
+  get_pkgconfig_deps(openjpip deps)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/lib/openjpip/libopenjpip.pc.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/libopenjpip.pc @ONLY)
   install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libopenjpip.pc DESTINATION

--- a/src/lib/openjp2/libopenjp2.pc.cmake.in
+++ b/src/lib/openjp2/libopenjp2.pc.cmake.in
@@ -10,6 +10,6 @@ Description: JPEG2000 library (Part 1 and 2)
 URL: http://www.openjpeg.org/
 Version: @OPENJPEG_VERSION@
 Libs: -L${libdir} -lopenjp2
-Libs.private: -lm
+Libs.private: @deps@
 Cflags: -I${includedir}
 Cflags.private: -DOPJ_STATIC

--- a/src/lib/openjpip/libopenjpip.pc.cmake.in
+++ b/src/lib/openjpip/libopenjpip.pc.cmake.in
@@ -11,6 +11,6 @@ URL: http://www.openjpeg.org/
 Version: @OPENJPEG_VERSION@
 Requires: libopenjp2
 Libs: -L${libdir} -lopenjpip
-Libs.private: -lm -lcurl -lfcgi -lpthread
+Libs.private: @deps@
 Cflags: -I${includedir}
 Cflags.private: -DOPJ_STATIC


### PR DESCRIPTION
Generate pkg-config `Libs.private` from the actual dependencies linked into our libraries, rather than hardcoding static lists, to avoid overlinking of library users when `pkg-config` is invoked with `--static`.  libopenjpip doesn't actually link with libcurl, libfcgi, or libpthread, and neither of our libraries links with libm on Windows (which doesn't have libm).