### PR TITLE
Fix parser hang when EOC marker appears before any SOT marker

### DIFF
--- a/src/lib/openjp2/j2k.c
+++ b/src/lib/openjp2/j2k.c
@@ -1420,6 +1420,7 @@ static const opj_dec_memory_marker_handler_t j2k_memory_marker_handler_tab [] =
     {J2K_MS_PLT, J2K_STATE_TPH, opj_j2k_read_plt},
     {J2K_MS_PPM, J2K_STATE_MH, opj_j2k_read_ppm},
     {J2K_MS_PPT, J2K_STATE_TPH, opj_j2k_read_ppt},
+    {J2K_MS_EOC, J2K_STATE_EOC, 0},
     {J2K_MS_SOP, 0, 0},
     {J2K_MS_CRG, J2K_STATE_MH, opj_j2k_read_crg},
     {J2K_MS_COM, J2K_STATE_MH | J2K_STATE_TPH, opj_j2k_read_com},


### PR DESCRIPTION
Under certain circumstances, an invalid JPEG2000 file, ie. when an EOC marker is encountered before any SOT marker, leads to an endless loop when trying to parse the header in opj_read_header.
Attached is a file where this error occurs.
[invalid.debug](https://github.com/user-attachments/files/23673702/invalid.debug)
