### PR TITLE
Fixed #1607

### DIFF
--- a/src/bin/jp2/opj_compress.c
+++ b/src/bin/jp2/opj_compress.c
@@ -709,7 +709,7 @@ static int parse_cmdline_encoder(int argc, char **argv,
         case 'O': {         /* output format */
             char outformat[50];
             char *of = opj_optarg;
-            sprintf(outformat, ".%s", of);
+            snprintf(outformat, sizeof(outformat), ".%s", of);
             img_fol->set_out_format = 1;
             parameters->cod_format = get_file_format(outformat);
             switch (parameters->cod_format) {

--- a/src/lib/openjp2/pi.c
+++ b/src/lib/openjp2/pi.c
@@ -1694,9 +1694,12 @@ opj_pi_iterator_t *opj_pi_initialise_encode(const opj_image_t *p_image,
     l_current_pi = l_pi;
 
     /* memory allocation for include*/
-    l_current_pi->include_size = l_tcp->numlayers * l_step_l;
-    l_current_pi->include = (OPJ_INT16*) opj_calloc(l_current_pi->include_size,
-                            sizeof(OPJ_INT16));
+    l_current_pi->include = 00;
+    if ((l_tcp->numlayers > 0U) && (l_step_l <= (UINT_MAX / l_tcp->numlayers))) {
+        l_current_pi->include_size = l_tcp->numlayers * l_step_l;
+        l_current_pi->include = (OPJ_INT16*) opj_calloc(l_current_pi->include_size,
+                                sizeof(OPJ_INT16));
+    }
     if (!l_current_pi->include) {
         opj_free(l_tmp_data);
         opj_free(l_tmp_ptr);


### PR DESCRIPTION
Add include_size check for preventing overflow #1607

and

Fixing [Bug] Protential stack-buffer-overflow crash in opj_compress.c