### PR TITLE
Address CVE-2023-39327, stop excessive loop errors

### DIFF
--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -441,6 +441,8 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
          * and no l_img_comp->resno_decoded are computed
          */
         OPJ_BOOL* first_pass_failed = NULL;
+        OPJ_UINT32 l_packet_count = 0;
+        OPJ_UINT32 l_max_packets = 100000;
 
         if (l_current_pi->poc.prg == OPJ_PROG_UNKNOWN) {
             /* TODO ADE : add an error */
@@ -457,6 +459,17 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
 
         while (opj_pi_next(l_current_pi)) {
             OPJ_BOOL skip_packet = OPJ_FALSE;
+            
+            /* CVE-2023-39327: Check for excessive packet iterations */
+            if (++l_packet_count > l_max_packets) {
+                opj_event_msg(p_manager, EVT_ERROR,
+                              "Excessive packet iterations detected (>%u). Possible malformed stream.\n",
+                              l_max_packets);
+                opj_pi_destroy(l_pi, l_nb_pocs);
+                opj_free(first_pass_failed);
+                return OPJ_FALSE;
+            }
+            
             JAS_FPRINTF(stderr,
                         "packet offset=00000166 prg=%d cmptno=%02d rlvlno=%02d prcno=%03d lyrno=%02d\n\n",
                         l_current_pi->poc.prg1, l_current_pi->compno, l_current_pi->resno,


### PR DESCRIPTION
Attempts to resolve https://github.com/uclouvain/openjpeg/issues/1472

Prevents excessive looping when consuming packets when errors are hit.

Validated with the steps below

## Testing

create bigloop file to validate the issue 
```
ÿOÿQ�,���d���������	��ü�����������BÿR�ÿ���"ÿ\�@@HHPÿd�-�Creator: AV-J2K (�Vator: AV-J2K (c) iotÿ�
������ÿÿÿOÿQ

```

### Baseline 
This establishes that there is an issue and that it breaks when the loop is excessive

Create a docker container from amazon linux 2023

Test script - test_baseline.sh
```bash
#!/bin/bash
set -e

echo "=== CVE-2023-39327 Baseline Test ==="
echo "Testing AL2023 baseline openjpeg2 with malicious PoC file"
echo ""

echo "[1] Installed version:"
rpm -q openjpeg2 openjpeg2-tools

# Test with the PoC file
echo ""
echo "[2] Testing with CVE-2023-39327 PoC file..."
echo "Running: timeout 10 opj2_decompress -i /test/bigloop -o /tmp/output.raw 2>&1 | wc -l"
echo ""

# Count total lines of output in 10 seconds
LINES=$(timeout 10 opj2_decompress -i /test/bigloop -o /tmp/output.raw 2>&1 | wc -l || true)

echo "Total output lines in 10 seconds: $LINES"
echo ""

if [ "$LINES" -gt 10000 ]; then
    echo "VULNERABLE: Excessive output detected ($LINES lines in 10s)"
    echo "The baseline version exhibits CVE-2023-39327 - infinite loop printing warnings."
    echo "This can consume CPU and fill logs indefinitely."
else
    echo "Output: $LINES lines in 10 seconds"
fi


```

Dockerfile
```docker
FROM public.ecr.aws/amazonlinux/amazonlinux:2023

# Install baseline openjpeg2 from AL2023 repos (vulnerable version)
RUN dnf install -y openjpeg2 openjpeg2-tools

# Copy test files
COPY bigloop /test/bigloop
COPY test_baseline.sh /test/test_baseline.sh

# Make script executable
RUN chmod +x /test/test_baseline.sh

# Run the test
CMD ["/test/test_baseline.sh"]
```

Run the container

```shell
# Build baseline test container
docker build -f Dockerfile.baseline -t openjpeg2-baseline-test .
# Run baseline test (should timeout showing vulnerability)
docker run --rm openjpeg2-baseline-test
```
see that there are many loop iterations and time out is hit


### Fixed


Test scipt to validate fix - test_cve_fix.sh
```bash
#!/bin/bash
set -e

echo "=== CVE-2023-39327 Test Script ==="
echo "Testing openjpeg2 with malicious PoC file"
echo ""

# Install the patched RPM
echo "[1] Installing patched openjpeg2 package..."
dnf install -y /rpms/openjpeg2-2.5.2-*.x86_64.rpm /rpms/openjpeg2-tools-2.5.2-*.x86_64.rpm 2>&1 | tail -5

# Check version
echo ""
echo "[2] Installed version:"
rpm -q openjpeg2 openjpeg2-tools

# Test with the PoC file
echo ""
echo "[3] Testing with CVE-2023-39327 PoC file (should fail fast, not loop)..."
echo "Running: timeout 10 opj2_decompress -i /test/bigloop -o /tmp/output.raw"
echo ""

# Run with timeout - should fail quickly with error, not timeout
if timeout 10 opj2_decompress -i /test/bigloop -o /tmp/output.raw 2>&1; then
    echo "ERROR: Command succeeded when it should have failed!"
    exit 1
else
    EXIT_CODE=$?
    if [ $EXIT_CODE -eq 124 ]; then
        echo "FAIL: Command timed out - infinite loop detected!"
        echo "The CVE fix is NOT working properly."
        exit 1
    else
        echo "SUCCESS: Command failed quickly (exit code: $EXIT_CODE)"
        echo "The CVE fix is working - no infinite loop detected."
        exit 0
    fi
fi

```

Docker file

```docker
FROM public.ecr.aws/amazonlinux/amazonlinux:2023

# Copy test files
COPY bigloop /test/bigloop
COPY test_cve_fix.sh /test/test_cve_fix.sh
COPY ../<path_to_rpms_with_fix>/ /rpms/

# Make script executable
RUN chmod +x /test/test_cve_fix.sh

# Run the test
CMD ["/test/test_cve_fix.sh"]

```

Run and build the tests 

```shell
# Build test container with patched RPMs
docker build -f Dockerfile.test -t openjpeg2-cve-test .

# Run test (should fail fast with loop detection)
docker run --rm openjpeg2-cve-test

```

See that the timeout is not hit