### PR TITLE
fix: reject zero-progress packet headers for CVE-2023-39327

### DIFF
--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -59,6 +59,11 @@ Variable length code for signalling delta Zil (truncation point)
 static void opj_t2_putnumpasses(opj_bio_t *bio, OPJ_UINT32 n);
 static OPJ_UINT32 opj_t2_getnumpasses(opj_bio_t *bio);
 
+typedef enum {
+    OPJ_PACKET_PROGRESSED = 0,
+    OPJ_PACKET_HEADERS_EXHAUSTED
+} opj_packet_progression_t;
+
 /**
 Encode a packet of a tile to a destination buffer
 @param tileno Number of the tile encoded
@@ -106,7 +111,7 @@ static OPJ_BOOL opj_t2_decode_packet(opj_t2_t* t2,
                                      OPJ_UINT32 * data_read,
                                      OPJ_UINT32 max_length,
                                      opj_packet_info_t *pack_info,
-                                     OPJ_BOOL *p_packet_headers_exhausted,
+                                     opj_packet_progression_t *p_progression,
                                      opj_event_mgr_t *p_manager);
 
 static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
@@ -117,7 +122,7 @@ static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
                                    OPJ_UINT32 * p_data_read,
                                    OPJ_UINT32 p_max_length,
                                    opj_packet_info_t *p_pack_info,
-                                   OPJ_BOOL *p_packet_headers_exhausted,
+                                   opj_packet_progression_t *p_progression,
                                    opj_event_mgr_t *p_manager);
 
 static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
@@ -129,7 +134,7 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
         OPJ_UINT32 * p_data_read,
         OPJ_UINT32 p_max_length,
         opj_packet_info_t *p_pack_info,
-        OPJ_BOOL *p_packet_headers_exhausted,
+        opj_packet_progression_t *p_progression,
         opj_event_mgr_t *p_manager);
 
 static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
@@ -469,7 +474,7 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
         }
         memset(first_pass_failed, OPJ_TRUE, l_image->numcomps * sizeof(OPJ_BOOL));
 
-        OPJ_BOOL packet_headers_exhausted = OPJ_FALSE;
+        opj_packet_progression_t progression = OPJ_PACKET_PROGRESSED;
 
         while (opj_pi_next(l_current_pi)) {
             OPJ_BOOL skip_packet = OPJ_FALSE;
@@ -526,12 +531,12 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
                 if (! opj_t2_decode_packet(p_t2, p_tile, l_tcp, l_current_pi,
                                            l_current_data, &l_nb_bytes_read,
                                            p_max_len, l_pack_info,
-                                           &packet_headers_exhausted, p_manager)) {
+                                           &progression, p_manager)) {
                     opj_pi_destroy(l_pi, l_nb_pocs);
                     opj_free(first_pass_failed);
                     return OPJ_FALSE;
                 }
-                if (packet_headers_exhausted) {
+                if (progression == OPJ_PACKET_HEADERS_EXHAUSTED) {
                     opj_t2_finalize_resno_decoded(l_image, p_tile);
                     break;
                 }
@@ -543,13 +548,13 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
                 l_nb_bytes_read = 0;
                 if (! opj_t2_skip_packet(p_t2, p_tile, l_tcp, l_current_pi,
                                          l_current_data, &l_nb_bytes_read, p_max_len,
-                                         l_pack_info, &packet_headers_exhausted,
+                                         l_pack_info, &progression,
                                          p_manager)) {
                     opj_pi_destroy(l_pi, l_nb_pocs);
                     opj_free(first_pass_failed);
                     return OPJ_FALSE;
                 }
-                if (packet_headers_exhausted) {
+                if (progression == OPJ_PACKET_HEADERS_EXHAUSTED) {
                     opj_t2_finalize_resno_decoded(l_image, p_tile);
                     break;
                 }
@@ -596,7 +601,7 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
             /* << INDEX */
         }
         opj_free(first_pass_failed);
-        if (packet_headers_exhausted) {
+        if (progression == OPJ_PACKET_HEADERS_EXHAUSTED) {
             break;
         }
         ++l_current_pi;
@@ -655,7 +660,7 @@ static OPJ_BOOL opj_t2_decode_packet(opj_t2_t* p_t2,
                                      OPJ_UINT32 * p_data_read,
                                      OPJ_UINT32 p_max_length,
                                      opj_packet_info_t *p_pack_info,
-                                     OPJ_BOOL *p_packet_headers_exhausted,
+                                     opj_packet_progression_t *p_progression,
                                      opj_event_mgr_t *p_manager)
 {
     OPJ_BOOL l_read_data;
@@ -663,14 +668,14 @@ static OPJ_BOOL opj_t2_decode_packet(opj_t2_t* p_t2,
     OPJ_UINT32 l_nb_total_bytes_read = 0;
 
     *p_data_read = 0;
-    *p_packet_headers_exhausted = OPJ_FALSE;
+    *p_progression = OPJ_PACKET_PROGRESSED;
 
     if (! opj_t2_read_packet_header(p_t2, p_tile, p_tcp, p_pi, &l_read_data, p_src,
                                     &l_nb_bytes_read, p_max_length, p_pack_info,
-                                    p_packet_headers_exhausted, p_manager)) {
+                                    p_progression, p_manager)) {
         return OPJ_FALSE;
     }
-    if (*p_packet_headers_exhausted) {
+    if (*p_progression == OPJ_PACKET_HEADERS_EXHAUSTED) {
         return OPJ_TRUE;
     }
 
@@ -1049,7 +1054,7 @@ static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
                                    OPJ_UINT32 * p_data_read,
                                    OPJ_UINT32 p_max_length,
                                    opj_packet_info_t *p_pack_info,
-                                   OPJ_BOOL *p_packet_headers_exhausted,
+                                   opj_packet_progression_t *p_progression,
                                    opj_event_mgr_t *p_manager)
 {
     OPJ_BOOL l_read_data;
@@ -1057,14 +1062,14 @@ static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
     OPJ_UINT32 l_nb_total_bytes_read = 0;
 
     *p_data_read = 0;
-    *p_packet_headers_exhausted = OPJ_FALSE;
+    *p_progression = OPJ_PACKET_PROGRESSED;
 
     if (! opj_t2_read_packet_header(p_t2, p_tile, p_tcp, p_pi, &l_read_data, p_src,
                                     &l_nb_bytes_read, p_max_length, p_pack_info,
-                                    p_packet_headers_exhausted, p_manager)) {
+                                    p_progression, p_manager)) {
         return OPJ_FALSE;
     }
-    if (*p_packet_headers_exhausted) {
+    if (*p_progression == OPJ_PACKET_HEADERS_EXHAUSTED) {
         return OPJ_TRUE;
     }
 
@@ -1098,7 +1103,7 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
         OPJ_UINT32 * p_data_read,
         OPJ_UINT32 p_max_length,
         opj_packet_info_t *p_pack_info,
-        OPJ_BOOL *p_packet_headers_exhausted,
+        opj_packet_progression_t *p_progression,
         opj_event_mgr_t *p_manager)
 
 {
@@ -1121,7 +1126,7 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
 
     OPJ_UINT32 l_present;
 
-    *p_packet_headers_exhausted = OPJ_FALSE;
+    *p_progression = OPJ_PACKET_PROGRESSED;
 
     if (p_pi->layno == 0) {
         l_band = l_res->bands;
@@ -1237,7 +1242,7 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
             /* Stop reading packet headers once an empty packet consumes no input at all. */
             *p_is_data_present = OPJ_FALSE;
             *p_data_read = 0U;
-            *p_packet_headers_exhausted = OPJ_TRUE;
+            *p_progression = OPJ_PACKET_HEADERS_EXHAUSTED;
             return OPJ_TRUE;
         }
         *l_modified_length_ptr -= l_header_length;

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1158,7 +1158,10 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
     JAS_FPRINTF(stderr, "present=%d \n", l_present);
     if (!l_present) {
         /* TODO MSD: no test to control the output of this function*/
-        opj_bio_inalign(l_bio);
+        if (!opj_bio_inalign(l_bio)) {
+            opj_bio_destroy(l_bio);
+            return OPJ_FALSE;
+        }
         l_header_data += opj_bio_numbytes(l_bio);
         opj_bio_destroy(l_bio);
 
@@ -1179,6 +1182,11 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
         }
 
         l_header_length = (OPJ_UINT32)(l_header_data - *l_header_data_start);
+        if (l_header_length == 0U) {
+            opj_event_msg(p_manager, EVT_ERROR,
+                          "Packet header decoding made no progress\n");
+            return OPJ_FALSE;
+        }
         *l_modified_length_ptr -= l_header_length;
         *l_header_data_start += l_header_length;
 
@@ -1361,6 +1369,8 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
     l_header_length = (OPJ_UINT32)(l_header_data - *l_header_data_start);
     JAS_FPRINTF(stderr, "hdrlen=%d \n", l_header_length);
     if (!l_header_length) {
+        opj_event_msg(p_manager, EVT_ERROR,
+                      "Packet header decoding made no progress\n");
         return OPJ_FALSE;
     }
     JAS_FPRINTF(stderr, "packet body\n");

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1233,12 +1233,6 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
 
         l_header_length = (OPJ_UINT32)(l_header_data - *l_header_data_start);
         if (l_header_length == 0U && l_current_data == p_src_data) {
-            if ((p_tcp->csty & J2K_CP_CSTY_SOP) != 0U) {
-                opj_event_msg(p_manager, EVT_ERROR,
-                              "Packet header decoding made no progress\n");
-                return OPJ_FALSE;
-            }
-
             /* Stop reading packet headers once an empty packet consumes no input at all. */
             *p_is_data_present = OPJ_FALSE;
             *p_data_read = 0U;

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -106,6 +106,7 @@ static OPJ_BOOL opj_t2_decode_packet(opj_t2_t* t2,
                                      OPJ_UINT32 * data_read,
                                      OPJ_UINT32 max_length,
                                      opj_packet_info_t *pack_info,
+                                     OPJ_BOOL *p_packet_headers_exhausted,
                                      opj_event_mgr_t *p_manager);
 
 static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
@@ -116,6 +117,7 @@ static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
                                    OPJ_UINT32 * p_data_read,
                                    OPJ_UINT32 p_max_length,
                                    opj_packet_info_t *p_pack_info,
+                                   OPJ_BOOL *p_packet_headers_exhausted,
                                    opj_event_mgr_t *p_manager);
 
 static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
@@ -127,6 +129,7 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
         OPJ_UINT32 * p_data_read,
         OPJ_UINT32 p_max_length,
         opj_packet_info_t *p_pack_info,
+        OPJ_BOOL *p_packet_headers_exhausted,
         opj_event_mgr_t *p_manager);
 
 static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
@@ -390,6 +393,17 @@ static void opj_null_jas_fprintf(FILE* file, const char * format, ...)
 #define JAS_FPRINTF opj_null_jas_fprintf
 #endif
 
+static void opj_t2_finalize_resno_decoded(opj_image_t *p_image,
+        opj_tcd_tile_t *p_tile)
+{
+    OPJ_UINT32 compno;
+
+    for (compno = 0; compno < p_image->numcomps; ++compno) {
+        p_image->comps[compno].resno_decoded =
+            p_tile->comps[compno].minimum_num_resolutions - 1;
+    }
+}
+
 OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
                                opj_t2_t *p_t2,
                                OPJ_UINT32 p_tile_no,
@@ -455,6 +469,8 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
         }
         memset(first_pass_failed, OPJ_TRUE, l_image->numcomps * sizeof(OPJ_BOOL));
 
+        OPJ_BOOL packet_headers_exhausted = OPJ_FALSE;
+
         while (opj_pi_next(l_current_pi)) {
             OPJ_BOOL skip_packet = OPJ_FALSE;
             JAS_FPRINTF(stderr,
@@ -507,11 +523,17 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
 
                 first_pass_failed[l_current_pi->compno] = OPJ_FALSE;
 
-                if (! opj_t2_decode_packet(p_t2, p_tile, l_tcp, l_current_pi, l_current_data,
-                                           &l_nb_bytes_read, p_max_len, l_pack_info, p_manager)) {
+                if (! opj_t2_decode_packet(p_t2, p_tile, l_tcp, l_current_pi,
+                                           l_current_data, &l_nb_bytes_read,
+                                           p_max_len, l_pack_info,
+                                           &packet_headers_exhausted, p_manager)) {
                     opj_pi_destroy(l_pi, l_nb_pocs);
                     opj_free(first_pass_failed);
                     return OPJ_FALSE;
+                }
+                if (packet_headers_exhausted) {
+                    opj_t2_finalize_resno_decoded(l_image, p_tile);
+                    break;
                 }
 
                 l_img_comp = &(l_image->comps[l_current_pi->compno]);
@@ -519,11 +541,17 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
                                             l_img_comp->resno_decoded);
             } else {
                 l_nb_bytes_read = 0;
-                if (! opj_t2_skip_packet(p_t2, p_tile, l_tcp, l_current_pi, l_current_data,
-                                         &l_nb_bytes_read, p_max_len, l_pack_info, p_manager)) {
+                if (! opj_t2_skip_packet(p_t2, p_tile, l_tcp, l_current_pi,
+                                         l_current_data, &l_nb_bytes_read, p_max_len,
+                                         l_pack_info, &packet_headers_exhausted,
+                                         p_manager)) {
                     opj_pi_destroy(l_pi, l_nb_pocs);
                     opj_free(first_pass_failed);
                     return OPJ_FALSE;
+                }
+                if (packet_headers_exhausted) {
+                    opj_t2_finalize_resno_decoded(l_image, p_tile);
+                    break;
                 }
             }
 
@@ -567,9 +595,11 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
 #endif
             /* << INDEX */
         }
-        ++l_current_pi;
-
         opj_free(first_pass_failed);
+        if (packet_headers_exhausted) {
+            break;
+        }
+        ++l_current_pi;
     }
     /* INDEX >> */
 #ifdef TODO_MSD
@@ -625,6 +655,7 @@ static OPJ_BOOL opj_t2_decode_packet(opj_t2_t* p_t2,
                                      OPJ_UINT32 * p_data_read,
                                      OPJ_UINT32 p_max_length,
                                      opj_packet_info_t *p_pack_info,
+                                     OPJ_BOOL *p_packet_headers_exhausted,
                                      opj_event_mgr_t *p_manager)
 {
     OPJ_BOOL l_read_data;
@@ -632,10 +663,15 @@ static OPJ_BOOL opj_t2_decode_packet(opj_t2_t* p_t2,
     OPJ_UINT32 l_nb_total_bytes_read = 0;
 
     *p_data_read = 0;
+    *p_packet_headers_exhausted = OPJ_FALSE;
 
     if (! opj_t2_read_packet_header(p_t2, p_tile, p_tcp, p_pi, &l_read_data, p_src,
-                                    &l_nb_bytes_read, p_max_length, p_pack_info, p_manager)) {
+                                    &l_nb_bytes_read, p_max_length, p_pack_info,
+                                    p_packet_headers_exhausted, p_manager)) {
         return OPJ_FALSE;
+    }
+    if (*p_packet_headers_exhausted) {
+        return OPJ_TRUE;
     }
 
     p_src += l_nb_bytes_read;
@@ -1013,6 +1049,7 @@ static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
                                    OPJ_UINT32 * p_data_read,
                                    OPJ_UINT32 p_max_length,
                                    opj_packet_info_t *p_pack_info,
+                                   OPJ_BOOL *p_packet_headers_exhausted,
                                    opj_event_mgr_t *p_manager)
 {
     OPJ_BOOL l_read_data;
@@ -1020,10 +1057,15 @@ static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
     OPJ_UINT32 l_nb_total_bytes_read = 0;
 
     *p_data_read = 0;
+    *p_packet_headers_exhausted = OPJ_FALSE;
 
     if (! opj_t2_read_packet_header(p_t2, p_tile, p_tcp, p_pi, &l_read_data, p_src,
-                                    &l_nb_bytes_read, p_max_length, p_pack_info, p_manager)) {
+                                    &l_nb_bytes_read, p_max_length, p_pack_info,
+                                    p_packet_headers_exhausted, p_manager)) {
         return OPJ_FALSE;
+    }
+    if (*p_packet_headers_exhausted) {
+        return OPJ_TRUE;
     }
 
     p_src += l_nb_bytes_read;
@@ -1056,6 +1098,7 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
         OPJ_UINT32 * p_data_read,
         OPJ_UINT32 p_max_length,
         opj_packet_info_t *p_pack_info,
+        OPJ_BOOL *p_packet_headers_exhausted,
         opj_event_mgr_t *p_manager)
 
 {
@@ -1077,6 +1120,8 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
     OPJ_BYTE **l_header_data_start = 00;
 
     OPJ_UINT32 l_present;
+
+    *p_packet_headers_exhausted = OPJ_FALSE;
 
     if (p_pi->layno == 0) {
         l_band = l_res->bands;
@@ -1182,12 +1227,18 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
         }
 
         l_header_length = (OPJ_UINT32)(l_header_data - *l_header_data_start);
-        if (l_header_length == 0U &&
-                l_current_data == p_src_data &&
-                (p_tcp->csty & J2K_CP_CSTY_SOP) != 0U) {
-            opj_event_msg(p_manager, EVT_ERROR,
-                          "Packet header decoding made no progress\n");
-            return OPJ_FALSE;
+        if (l_header_length == 0U && l_current_data == p_src_data) {
+            if ((p_tcp->csty & J2K_CP_CSTY_SOP) != 0U) {
+                opj_event_msg(p_manager, EVT_ERROR,
+                              "Packet header decoding made no progress\n");
+                return OPJ_FALSE;
+            }
+
+            /* Stop reading packet headers once an empty packet consumes no input at all. */
+            *p_is_data_present = OPJ_FALSE;
+            *p_data_read = 0U;
+            *p_packet_headers_exhausted = OPJ_TRUE;
+            return OPJ_TRUE;
         }
         *l_modified_length_ptr -= l_header_length;
         *l_header_data_start += l_header_length;

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -1182,7 +1182,9 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
         }
 
         l_header_length = (OPJ_UINT32)(l_header_data - *l_header_data_start);
-        if (l_header_length == 0U) {
+        if (l_header_length == 0U &&
+                l_current_data == p_src_data &&
+                (p_tcp->csty & J2K_CP_CSTY_SOP) != 0U) {
             opj_event_msg(p_manager, EVT_ERROR,
                           "Packet header decoding made no progress\n");
             return OPJ_FALSE;

--- a/src/lib/openjp2/t2.c
+++ b/src/lib/openjp2/t2.c
@@ -59,11 +59,6 @@ Variable length code for signalling delta Zil (truncation point)
 static void opj_t2_putnumpasses(opj_bio_t *bio, OPJ_UINT32 n);
 static OPJ_UINT32 opj_t2_getnumpasses(opj_bio_t *bio);
 
-typedef enum {
-    OPJ_PACKET_PROGRESSED = 0,
-    OPJ_PACKET_HEADERS_EXHAUSTED
-} opj_packet_progression_t;
-
 /**
 Encode a packet of a tile to a destination buffer
 @param tileno Number of the tile encoded
@@ -111,7 +106,7 @@ static OPJ_BOOL opj_t2_decode_packet(opj_t2_t* t2,
                                      OPJ_UINT32 * data_read,
                                      OPJ_UINT32 max_length,
                                      opj_packet_info_t *pack_info,
-                                     opj_packet_progression_t *p_progression,
+                                     OPJ_BOOL *p_headers_exhausted,
                                      opj_event_mgr_t *p_manager);
 
 static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
@@ -122,7 +117,7 @@ static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
                                    OPJ_UINT32 * p_data_read,
                                    OPJ_UINT32 p_max_length,
                                    opj_packet_info_t *p_pack_info,
-                                   opj_packet_progression_t *p_progression,
+                                   OPJ_BOOL *p_headers_exhausted,
                                    opj_event_mgr_t *p_manager);
 
 static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
@@ -134,7 +129,7 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
         OPJ_UINT32 * p_data_read,
         OPJ_UINT32 p_max_length,
         opj_packet_info_t *p_pack_info,
-        opj_packet_progression_t *p_progression,
+        OPJ_BOOL *p_headers_exhausted,
         opj_event_mgr_t *p_manager);
 
 static OPJ_BOOL opj_t2_read_packet_data(opj_t2_t* p_t2,
@@ -403,6 +398,12 @@ static void opj_t2_finalize_resno_decoded(opj_image_t *p_image,
 {
     OPJ_UINT32 compno;
 
+    /* Match where the tolerant truncated-stream iteration used to converge:
+     * every component ends at minimum_num_resolutions - 1. Decoded packets
+     * never exceed that resolution (see the skip condition on
+     * minimum_num_resolutions in opj_t2_decode_packets), so this never
+     * lowers a value, and it keeps resno_decoded equal across components,
+     * which the MCT stage requires. */
     for (compno = 0; compno < p_image->numcomps; ++compno) {
         p_image->comps[compno].resno_decoded =
             p_tile->comps[compno].minimum_num_resolutions - 1;
@@ -460,6 +461,7 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
          * and no l_img_comp->resno_decoded are computed
          */
         OPJ_BOOL* first_pass_failed = NULL;
+        OPJ_BOOL l_headers_exhausted = OPJ_FALSE;
 
         if (l_current_pi->poc.prg == OPJ_PROG_UNKNOWN) {
             /* TODO ADE : add an error */
@@ -473,8 +475,6 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
             return OPJ_FALSE;
         }
         memset(first_pass_failed, OPJ_TRUE, l_image->numcomps * sizeof(OPJ_BOOL));
-
-        opj_packet_progression_t progression = OPJ_PACKET_PROGRESSED;
 
         while (opj_pi_next(l_current_pi)) {
             OPJ_BOOL skip_packet = OPJ_FALSE;
@@ -531,13 +531,12 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
                 if (! opj_t2_decode_packet(p_t2, p_tile, l_tcp, l_current_pi,
                                            l_current_data, &l_nb_bytes_read,
                                            p_max_len, l_pack_info,
-                                           &progression, p_manager)) {
+                                           &l_headers_exhausted, p_manager)) {
                     opj_pi_destroy(l_pi, l_nb_pocs);
                     opj_free(first_pass_failed);
                     return OPJ_FALSE;
                 }
-                if (progression == OPJ_PACKET_HEADERS_EXHAUSTED) {
-                    opj_t2_finalize_resno_decoded(l_image, p_tile);
+                if (l_headers_exhausted) {
                     break;
                 }
 
@@ -548,14 +547,13 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
                 l_nb_bytes_read = 0;
                 if (! opj_t2_skip_packet(p_t2, p_tile, l_tcp, l_current_pi,
                                          l_current_data, &l_nb_bytes_read, p_max_len,
-                                         l_pack_info, &progression,
+                                         l_pack_info, &l_headers_exhausted,
                                          p_manager)) {
                     opj_pi_destroy(l_pi, l_nb_pocs);
                     opj_free(first_pass_failed);
                     return OPJ_FALSE;
                 }
-                if (progression == OPJ_PACKET_HEADERS_EXHAUSTED) {
-                    opj_t2_finalize_resno_decoded(l_image, p_tile);
+                if (l_headers_exhausted) {
                     break;
                 }
             }
@@ -601,7 +599,8 @@ OPJ_BOOL opj_t2_decode_packets(opj_tcd_t* tcd,
             /* << INDEX */
         }
         opj_free(first_pass_failed);
-        if (progression == OPJ_PACKET_HEADERS_EXHAUSTED) {
+        if (l_headers_exhausted) {
+            opj_t2_finalize_resno_decoded(l_image, p_tile);
             break;
         }
         ++l_current_pi;
@@ -660,7 +659,7 @@ static OPJ_BOOL opj_t2_decode_packet(opj_t2_t* p_t2,
                                      OPJ_UINT32 * p_data_read,
                                      OPJ_UINT32 p_max_length,
                                      opj_packet_info_t *p_pack_info,
-                                     opj_packet_progression_t *p_progression,
+                                     OPJ_BOOL *p_headers_exhausted,
                                      opj_event_mgr_t *p_manager)
 {
     OPJ_BOOL l_read_data;
@@ -668,15 +667,11 @@ static OPJ_BOOL opj_t2_decode_packet(opj_t2_t* p_t2,
     OPJ_UINT32 l_nb_total_bytes_read = 0;
 
     *p_data_read = 0;
-    *p_progression = OPJ_PACKET_PROGRESSED;
 
     if (! opj_t2_read_packet_header(p_t2, p_tile, p_tcp, p_pi, &l_read_data, p_src,
                                     &l_nb_bytes_read, p_max_length, p_pack_info,
-                                    p_progression, p_manager)) {
+                                    p_headers_exhausted, p_manager)) {
         return OPJ_FALSE;
-    }
-    if (*p_progression == OPJ_PACKET_HEADERS_EXHAUSTED) {
-        return OPJ_TRUE;
     }
 
     p_src += l_nb_bytes_read;
@@ -1054,7 +1049,7 @@ static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
                                    OPJ_UINT32 * p_data_read,
                                    OPJ_UINT32 p_max_length,
                                    opj_packet_info_t *p_pack_info,
-                                   opj_packet_progression_t *p_progression,
+                                   OPJ_BOOL *p_headers_exhausted,
                                    opj_event_mgr_t *p_manager)
 {
     OPJ_BOOL l_read_data;
@@ -1062,15 +1057,11 @@ static OPJ_BOOL opj_t2_skip_packet(opj_t2_t* p_t2,
     OPJ_UINT32 l_nb_total_bytes_read = 0;
 
     *p_data_read = 0;
-    *p_progression = OPJ_PACKET_PROGRESSED;
 
     if (! opj_t2_read_packet_header(p_t2, p_tile, p_tcp, p_pi, &l_read_data, p_src,
                                     &l_nb_bytes_read, p_max_length, p_pack_info,
-                                    p_progression, p_manager)) {
+                                    p_headers_exhausted, p_manager)) {
         return OPJ_FALSE;
-    }
-    if (*p_progression == OPJ_PACKET_HEADERS_EXHAUSTED) {
-        return OPJ_TRUE;
     }
 
     p_src += l_nb_bytes_read;
@@ -1103,7 +1094,7 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
         OPJ_UINT32 * p_data_read,
         OPJ_UINT32 p_max_length,
         opj_packet_info_t *p_pack_info,
-        opj_packet_progression_t *p_progression,
+        OPJ_BOOL *p_headers_exhausted,
         opj_event_mgr_t *p_manager)
 
 {
@@ -1126,7 +1117,7 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
 
     OPJ_UINT32 l_present;
 
-    *p_progression = OPJ_PACKET_PROGRESSED;
+    *p_headers_exhausted = OPJ_FALSE;
 
     if (p_pi->layno == 0) {
         l_band = l_res->bands;
@@ -1232,12 +1223,11 @@ static OPJ_BOOL opj_t2_read_packet_header(opj_t2_t* p_t2,
         }
 
         l_header_length = (OPJ_UINT32)(l_header_data - *l_header_data_start);
-        if (l_header_length == 0U && l_current_data == p_src_data) {
-            /* Stop reading packet headers once an empty packet consumes no input at all. */
-            *p_is_data_present = OPJ_FALSE;
-            *p_data_read = 0U;
-            *p_progression = OPJ_PACKET_HEADERS_EXHAUSTED;
-            return OPJ_TRUE;
+        if (l_header_length == 0U) {
+            /* An empty packet whose header consumed no byte can only occur
+             * when the packet header source (codestream remainder, or the
+             * PPM/PPT buffer) is exhausted: stop reading packet headers. */
+            *p_headers_exhausted = OPJ_TRUE;
         }
         *l_modified_length_ptr -= l_header_length;
         *l_header_data_start += l_header_length;

--- a/tests/fuzzers/build_seed_corpus.sh
+++ b/tests/fuzzers/build_seed_corpus.sh
@@ -7,12 +7,43 @@ if [ "$OUT" == "" ]; then
     exit 1
 fi
 
+mkdir -p "$OUT"
+
 SRC_DIR=$(dirname $0)/../..
+ISSUE1472_SEED="$SRC_DIR/data/input/nonregression/issue1472-bigloop.j2k"
+ISSUE1472_TMP_DIR=""
+
+cleanup()
+{
+    if [ "$ISSUE1472_TMP_DIR" != "" ]; then
+        rm -rf "$ISSUE1472_TMP_DIR"
+    fi
+}
+
+trap cleanup EXIT
 
 cd $SRC_DIR/data/input/conformance
 rm -f $OUT/opj_decompress_fuzzer_seed_corpus.zip
 zip $OUT/opj_decompress_fuzzer_seed_corpus.zip *.jp2 *.j2k
 cd $OLDPWD
+
+if [ -f "$ISSUE1472_SEED" ]; then
+    ISSUE1472_TMP_DIR=$(mktemp -d "$OUT/issue1472-seeds.XXXXXX")
+
+    cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop.j2k"
+    cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop-noeph.j2k"
+    cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop-prt-only.j2k"
+
+    # Byte 52 is the COD Scod value in the upstream issue1472 seed.
+    printf '\003' | dd of="$ISSUE1472_TMP_DIR/issue1472-bigloop-noeph.j2k" \
+        bs=1 seek=52 conv=notrunc
+    printf '\001' | dd of="$ISSUE1472_TMP_DIR/issue1472-bigloop-prt-only.j2k" \
+        bs=1 seek=52 conv=notrunc
+
+    cd "$ISSUE1472_TMP_DIR"
+    zip "$OUT/opj_decompress_fuzzer_seed_corpus.zip" issue1472-bigloop*.j2k
+    cd "$OLDPWD"
+fi
 
 cd $SRC_DIR/data/input/nonregression/htj2k
 zip $OUT/opj_decompress_fuzzer_seed_corpus.zip *.j2k *.jhc *.jph

--- a/tests/fuzzers/build_seed_corpus.sh
+++ b/tests/fuzzers/build_seed_corpus.sh
@@ -29,6 +29,12 @@ cd $OLDPWD
 
 if [ -f "$ISSUE1472_SEED" ]; then
     ISSUE1472_TMP_DIR=$(mktemp -d "$OUT/issue1472-seeds.XXXXXX")
+    ISSUE1472_SCOD=$(od -An -tx1 -j 52 -N 1 "$ISSUE1472_SEED" | tr -d ' \n')
+
+    if [ "$ISSUE1472_SCOD" != "07" ]; then
+        echo "Unexpected Scod byte in $ISSUE1472_SEED: 0x$ISSUE1472_SCOD"
+        exit 1
+    fi
 
     cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop.j2k"
     cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop-noeph.j2k"

--- a/tests/fuzzers/build_seed_corpus.sh
+++ b/tests/fuzzers/build_seed_corpus.sh
@@ -11,44 +11,36 @@ mkdir -p "$OUT"
 
 SRC_DIR=$(dirname $0)/../..
 ISSUE1472_SEED="$SRC_DIR/data/input/nonregression/issue1472-bigloop.j2k"
-ISSUE1472_TMP_DIR=""
-
-cleanup()
-{
-    if [ "$ISSUE1472_TMP_DIR" != "" ]; then
-        rm -rf "$ISSUE1472_TMP_DIR"
-    fi
-}
-
-trap cleanup EXIT
 
 cd $SRC_DIR/data/input/conformance
 rm -f $OUT/opj_decompress_fuzzer_seed_corpus.zip
 zip $OUT/opj_decompress_fuzzer_seed_corpus.zip *.jp2 *.j2k
 cd $OLDPWD
 
+# Byte 52 is the COD Scod value in the upstream issue1472 seed; only derive
+# the CVE-2023-39327 Scod variants if the seed still has its known layout.
 if [ -f "$ISSUE1472_SEED" ]; then
-    ISSUE1472_TMP_DIR=$(mktemp -d "$OUT/issue1472-seeds.XXXXXX")
     ISSUE1472_SCOD=$(od -An -tx1 -j 52 -N 1 "$ISSUE1472_SEED" | tr -d ' \n')
 
     if [ "$ISSUE1472_SCOD" != "07" ]; then
-        echo "Unexpected Scod byte in $ISSUE1472_SEED: 0x$ISSUE1472_SCOD"
-        exit 1
+        echo "Warning: unexpected Scod byte in $ISSUE1472_SEED: 0x$ISSUE1472_SCOD; skipping issue1472 seed variants"
+    else
+        ISSUE1472_TMP_DIR=$(mktemp -d)
+        trap 'rm -rf "$ISSUE1472_TMP_DIR"' EXIT
+
+        cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop.j2k"
+        cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop-noeph.j2k"
+        cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop-prt-only.j2k"
+
+        printf '\003' | dd of="$ISSUE1472_TMP_DIR/issue1472-bigloop-noeph.j2k" \
+            bs=1 seek=52 conv=notrunc
+        printf '\001' | dd of="$ISSUE1472_TMP_DIR/issue1472-bigloop-prt-only.j2k" \
+            bs=1 seek=52 conv=notrunc
+
+        cd "$ISSUE1472_TMP_DIR"
+        zip "$OUT/opj_decompress_fuzzer_seed_corpus.zip" issue1472-bigloop*.j2k
+        cd "$OLDPWD"
     fi
-
-    cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop.j2k"
-    cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop-noeph.j2k"
-    cp "$ISSUE1472_SEED" "$ISSUE1472_TMP_DIR/issue1472-bigloop-prt-only.j2k"
-
-    # Byte 52 is the COD Scod value in the upstream issue1472 seed.
-    printf '\003' | dd of="$ISSUE1472_TMP_DIR/issue1472-bigloop-noeph.j2k" \
-        bs=1 seek=52 conv=notrunc
-    printf '\001' | dd of="$ISSUE1472_TMP_DIR/issue1472-bigloop-prt-only.j2k" \
-        bs=1 seek=52 conv=notrunc
-
-    cd "$ISSUE1472_TMP_DIR"
-    zip "$OUT/opj_decompress_fuzzer_seed_corpus.zip" issue1472-bigloop*.j2k
-    cd "$OLDPWD"
 fi
 
 cd $SRC_DIR/data/input/nonregression/htj2k

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach(ut ${unit_test})
   add_test(NAME ${ut} COMMAND ${ut})
 endforeach()
 
-set_tests_properties(testissue1472_noeph PROPERTIES TIMEOUT 5)
+set_tests_properties(testissue1472_noeph PROPERTIES TIMEOUT 10)
 
 add_executable(testjp2 testjp2.c)
 target_link_libraries(testjp2 openjp2)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -14,7 +14,11 @@ set(unit_test
 foreach(ut ${unit_test})
   add_executable(${ut} ${ut}.c)
   target_link_libraries(${ut} openjp2)
-  add_test(NAME ${ut} COMMAND ${ut})
+  if(${ut} STREQUAL "testissue1472_noeph")
+    add_test(NAME ${ut} COMMAND ${ut} ${OPJ_DATA_ROOT})
+  else()
+    add_test(NAME ${ut} COMMAND ${ut})
+  endif()
 endforeach()
 
 set_tests_properties(testissue1472_noeph PROPERTIES TIMEOUT 10)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -9,12 +9,15 @@ set(unit_test
   testempty0
   testempty1
   testempty2
+  testissue1472_noeph
 )
 foreach(ut ${unit_test})
   add_executable(${ut} ${ut}.c)
   target_link_libraries(${ut} openjp2)
   add_test(NAME ${ut} COMMAND ${ut})
 endforeach()
+
+set_tests_properties(testissue1472_noeph PROPERTIES TIMEOUT 5)
 
 add_executable(testjp2 testjp2.c)
 target_link_libraries(testjp2 openjp2)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -21,7 +21,9 @@ foreach(ut ${unit_test})
   endif()
 endforeach()
 
-set_tests_properties(testissue1472_noeph PROPERTIES TIMEOUT 10)
+# Guards against the pre-fix issue1472 unbounded loop (which never returned);
+# generous enough for slow or instrumented (valgrind/sanitizer) runs.
+set_tests_properties(testissue1472_noeph PROPERTIES TIMEOUT 30)
 
 add_executable(testjp2 testjp2.c)
 target_link_libraries(testjp2 openjp2)

--- a/tests/unit/testissue1472_noeph.c
+++ b/tests/unit/testissue1472_noeph.c
@@ -205,18 +205,13 @@ static OPJ_BOOL test_enable_sop_csty(OPJ_BYTE *data, OPJ_SIZE_T data_len)
     return OPJ_FALSE;
 }
 
-static int test_sop_optional_tolerated_eof(const char *data_root)
+static int test_sop_optional_tolerated_eof_fixture(const char *data_root,
+        const char *relative_filename)
 {
-    const char *relative_filename =
-        "/input/nonregression/dwt_interleave_h.gsr105.jp2";
     char filename[4096];
     OPJ_SIZE_T data_len;
     OPJ_BYTE *data;
     test_decode_result_t result;
-
-    if (data_root == NULL || strstr(data_root, "OPJ_DATA_ROOT-NOTFOUND") != NULL) {
-        return 0;
-    }
 
     if (snprintf(filename, sizeof(filename), "%s%s", data_root,
                  relative_filename) >= (int)sizeof(filename)) {
@@ -240,8 +235,30 @@ static int test_sop_optional_tolerated_eof(const char *data_root)
     free(data);
 
     if (result != TEST_DECODE_SUCCESS) {
-        fprintf(stderr, "SOP-bit/no-SOP tolerated EOF fixture failed to decode\n");
+        fprintf(stderr, "SOP-bit/no-SOP tolerated EOF fixture failed to decode: %s\n",
+                filename);
         return 1;
+    }
+
+    return 0;
+}
+
+static int test_sop_optional_tolerated_eof(const char *data_root)
+{
+    static const char *fixtures[] = {
+        "/input/nonregression/Marrin.jp2",
+        "/input/nonregression/dwt_interleave_h.gsr105.jp2"
+    };
+    size_t i;
+
+    if (data_root == NULL || strstr(data_root, "OPJ_DATA_ROOT-NOTFOUND") != NULL) {
+        return 0;
+    }
+
+    for (i = 0U; i < sizeof(fixtures) / sizeof(fixtures[0]); ++i) {
+        if (test_sop_optional_tolerated_eof_fixture(data_root, fixtures[i]) != 0) {
+            return 1;
+        }
     }
 
     return 0;

--- a/tests/unit/testissue1472_noeph.c
+++ b/tests/unit/testissue1472_noeph.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "openjpeg.h"
@@ -16,6 +17,7 @@ typedef enum {
 } test_decode_result_t;
 
 #define ISSUE1472_SCOD_OFFSET 52
+#define TEST_CSTY_SOP 0x02
 
 static const OPJ_BYTE issue1472_noeph[] = {
     0xff, 0x4f, 0xff, 0x51, 0x00, 0x2c, 0x00, 0x02, 0x04, 0x00, 0x00, 0x64,
@@ -92,7 +94,7 @@ static void test_set_scod(OPJ_BYTE *dst, OPJ_BYTE scod)
 }
 
 static test_decode_result_t test_decode_codestream(const OPJ_BYTE *data,
-        OPJ_SIZE_T data_len)
+        OPJ_SIZE_T data_len, OPJ_CODEC_FORMAT codec_format)
 {
     test_mem_stream_t mem_stream;
     opj_stream_t *stream = NULL;
@@ -116,7 +118,7 @@ static test_decode_result_t test_decode_codestream(const OPJ_BYTE *data,
     opj_stream_set_skip_function(stream, test_skip_callback);
     opj_stream_set_seek_function(stream, test_seek_callback);
 
-    codec = opj_create_decompress(OPJ_CODEC_J2K);
+    codec = opj_create_decompress(codec_format);
     if (codec == NULL) {
         opj_stream_destroy(stream);
         return TEST_DECODE_HEADER_FAILURE;
@@ -145,13 +147,114 @@ cleanup:
     return result;
 }
 
-int main(void)
+static OPJ_BYTE *test_read_file(const char *filename, OPJ_SIZE_T *data_len)
+{
+    FILE *fp = fopen(filename, "rb");
+    long file_len;
+    OPJ_BYTE *data;
+
+    *data_len = 0U;
+    if (fp == NULL) {
+        return NULL;
+    }
+
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        fclose(fp);
+        return NULL;
+    }
+
+    file_len = ftell(fp);
+    if (file_len <= 0) {
+        fclose(fp);
+        return NULL;
+    }
+
+    if (fseek(fp, 0, SEEK_SET) != 0) {
+        fclose(fp);
+        return NULL;
+    }
+
+    data = (OPJ_BYTE *)malloc((size_t)file_len);
+    if (data == NULL) {
+        fclose(fp);
+        return NULL;
+    }
+
+    if (fread(data, 1U, (size_t)file_len, fp) != (size_t)file_len) {
+        free(data);
+        fclose(fp);
+        return NULL;
+    }
+
+    fclose(fp);
+    *data_len = (OPJ_SIZE_T)file_len;
+    return data;
+}
+
+static OPJ_BOOL test_enable_sop_csty(OPJ_BYTE *data, OPJ_SIZE_T data_len)
+{
+    OPJ_SIZE_T offset;
+
+    for (offset = 0U; offset + 4U < data_len; ++offset) {
+        if (data[offset] == 0xffU && data[offset + 1U] == 0x52U) {
+            data[offset + 4U] |= TEST_CSTY_SOP;
+            return OPJ_TRUE;
+        }
+    }
+
+    return OPJ_FALSE;
+}
+
+static int test_sop_optional_tolerated_eof(const char *data_root)
+{
+    const char *relative_filename =
+        "/input/nonregression/dwt_interleave_h.gsr105.jp2";
+    char filename[4096];
+    OPJ_SIZE_T data_len;
+    OPJ_BYTE *data;
+    test_decode_result_t result;
+
+    if (data_root == NULL || strstr(data_root, "OPJ_DATA_ROOT-NOTFOUND") != NULL) {
+        return 0;
+    }
+
+    if (snprintf(filename, sizeof(filename), "%s%s", data_root,
+                 relative_filename) >= (int)sizeof(filename)) {
+        fprintf(stderr, "Test fixture path is too long\n");
+        return 1;
+    }
+
+    data = test_read_file(filename, &data_len);
+    if (data == NULL) {
+        fprintf(stderr, "Unable to read test fixture %s\n", filename);
+        return 1;
+    }
+
+    if (!test_enable_sop_csty(data, data_len)) {
+        fprintf(stderr, "Unable to find COD Scod byte in %s\n", filename);
+        free(data);
+        return 1;
+    }
+
+    result = test_decode_codestream(data, data_len, OPJ_CODEC_JP2);
+    free(data);
+
+    if (result != TEST_DECODE_SUCCESS) {
+        fprintf(stderr, "SOP-bit/no-SOP tolerated EOF fixture failed to decode\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv)
 {
     OPJ_BYTE issue1472_prt_only[sizeof(issue1472_noeph)];
     OPJ_BYTE issue1472_eph_required[sizeof(issue1472_noeph)];
     test_decode_result_t result;
 
-    result = test_decode_codestream(issue1472_noeph, sizeof(issue1472_noeph));
+    result = test_decode_codestream(issue1472_noeph, sizeof(issue1472_noeph),
+                                    OPJ_CODEC_J2K);
     if (result != TEST_DECODE_FAILURE) {
         fprintf(stderr, "Malformed no-EPH codestream unexpectedly avoided decode failure\n");
         return 1;
@@ -159,7 +262,8 @@ int main(void)
 
     test_set_scod(issue1472_prt_only, 0x01);
 
-    result = test_decode_codestream(issue1472_prt_only, sizeof(issue1472_prt_only));
+    result = test_decode_codestream(issue1472_prt_only, sizeof(issue1472_prt_only),
+                                    OPJ_CODEC_J2K);
     if (result != TEST_DECODE_FAILURE) {
         fprintf(stderr, "PRT-only malformed codestream unexpectedly avoided decode failure\n");
         return 1;
@@ -168,11 +272,11 @@ int main(void)
     test_set_scod(issue1472_eph_required, 0x07);
 
     result = test_decode_codestream(issue1472_eph_required,
-                                    sizeof(issue1472_eph_required));
+                                    sizeof(issue1472_eph_required), OPJ_CODEC_J2K);
     if (result != TEST_DECODE_FAILURE) {
         fprintf(stderr, "EPH-required malformed codestream unexpectedly avoided decode failure\n");
         return 1;
     }
 
-    return 0;
+    return test_sop_optional_tolerated_eof(argc > 1 ? argv[1] : NULL);
 }

--- a/tests/unit/testissue1472_noeph.c
+++ b/tests/unit/testissue1472_noeph.c
@@ -9,6 +9,14 @@ typedef struct {
     OPJ_SIZE_T offset;
 } test_mem_stream_t;
 
+typedef enum {
+    TEST_DECODE_HEADER_FAILURE = -1,
+    TEST_DECODE_FAILURE = 0,
+    TEST_DECODE_SUCCESS = 1
+} test_decode_result_t;
+
+#define ISSUE1472_SCOD_OFFSET 52
+
 static const OPJ_BYTE issue1472_noeph[] = {
     0xff, 0x4f, 0xff, 0x51, 0x00, 0x2c, 0x00, 0x02, 0x04, 0x00, 0x00, 0x64,
     0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x09,
@@ -77,35 +85,35 @@ static OPJ_BOOL test_seek_callback(OPJ_OFF_T p_nb_bytes, void * p_user_data)
     return OPJ_TRUE;
 }
 
-int main(void)
+static test_decode_result_t test_decode_codestream(const OPJ_BYTE *data,
+        OPJ_SIZE_T data_len)
 {
     test_mem_stream_t mem_stream;
     opj_stream_t *stream = NULL;
     opj_codec_t *codec = NULL;
     opj_image_t *image = NULL;
     opj_dparameters_t parameters;
+    test_decode_result_t result = TEST_DECODE_HEADER_FAILURE;
 
-    mem_stream.data = issue1472_noeph;
-    mem_stream.data_len = sizeof(issue1472_noeph);
+    mem_stream.data = data;
+    mem_stream.data_len = data_len;
     mem_stream.offset = 0U;
 
     stream = opj_stream_create(1024, OPJ_TRUE);
     if (stream == NULL) {
-        fprintf(stderr, "Failed to create input stream\n");
-        return 1;
+        return TEST_DECODE_HEADER_FAILURE;
     }
 
     opj_stream_set_user_data(stream, &mem_stream, NULL);
-    opj_stream_set_user_data_length(stream, sizeof(issue1472_noeph));
+    opj_stream_set_user_data_length(stream, data_len);
     opj_stream_set_read_function(stream, test_read_callback);
     opj_stream_set_skip_function(stream, test_skip_callback);
     opj_stream_set_seek_function(stream, test_seek_callback);
 
     codec = opj_create_decompress(OPJ_CODEC_J2K);
     if (codec == NULL) {
-        fprintf(stderr, "Failed to create decoder\n");
         opj_stream_destroy(stream);
-        return 1;
+        return TEST_DECODE_HEADER_FAILURE;
     }
 
     opj_set_info_handler(codec, test_info_callback, NULL);
@@ -114,30 +122,42 @@ int main(void)
 
     opj_set_default_decoder_parameters(&parameters);
     if (!opj_setup_decoder(codec, &parameters)) {
-        fprintf(stderr, "Failed to setup decoder\n");
-        opj_destroy_codec(codec);
-        opj_stream_destroy(stream);
-        return 1;
+        goto cleanup;
     }
 
     if (!opj_read_header(stream, codec, &image)) {
-        fprintf(stderr, "Expected the malformed codestream to reach packet decoding\n");
-        opj_destroy_codec(codec);
-        opj_stream_destroy(stream);
-        opj_image_destroy(image);
-        return 1;
+        goto cleanup;
     }
 
-    if (opj_decode(codec, stream, image)) {
-        fprintf(stderr, "Malformed codestream unexpectedly decoded successfully\n");
-        opj_destroy_codec(codec);
-        opj_stream_destroy(stream);
-        opj_image_destroy(image);
-        return 1;
-    }
+    result = opj_decode(codec, stream, image) ? TEST_DECODE_SUCCESS :
+             TEST_DECODE_FAILURE;
 
+cleanup:
     opj_destroy_codec(codec);
     opj_stream_destroy(stream);
     opj_image_destroy(image);
+    return result;
+}
+
+int main(void)
+{
+    OPJ_BYTE issue1472_prt_only[sizeof(issue1472_noeph)];
+    test_decode_result_t result;
+
+    result = test_decode_codestream(issue1472_noeph, sizeof(issue1472_noeph));
+    if (result != TEST_DECODE_FAILURE) {
+        fprintf(stderr, "Malformed no-EPH codestream unexpectedly avoided decode failure\n");
+        return 1;
+    }
+
+    memcpy(issue1472_prt_only, issue1472_noeph, sizeof(issue1472_prt_only));
+    issue1472_prt_only[ISSUE1472_SCOD_OFFSET] = 0x01;
+
+    result = test_decode_codestream(issue1472_prt_only, sizeof(issue1472_prt_only));
+    if (result == TEST_DECODE_HEADER_FAILURE) {
+        fprintf(stderr, "Expected the PRT-only variant to reach packet decoding\n");
+        return 1;
+    }
+
     return 0;
 }

--- a/tests/unit/testissue1472_noeph.c
+++ b/tests/unit/testissue1472_noeph.c
@@ -1,0 +1,143 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "openjpeg.h"
+
+typedef struct {
+    const OPJ_BYTE* data;
+    OPJ_SIZE_T data_len;
+    OPJ_SIZE_T offset;
+} test_mem_stream_t;
+
+static const OPJ_BYTE issue1472_noeph[] = {
+    0xff, 0x4f, 0xff, 0x51, 0x00, 0x2c, 0x00, 0x02, 0x04, 0x00, 0x00, 0x64,
+    0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x09,
+    0x00, 0x00, 0xfc, 0x0b, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x07, 0x04, 0x01, 0x07, 0x42, 0x01,
+    0xff, 0x52, 0x00, 0x0e, 0x03, 0x04, 0xff, 0x01, 0x00, 0x01, 0x04, 0x04,
+    0x00, 0x01, 0x00, 0x22, 0xff, 0x5c, 0x00, 0x07, 0x40, 0x40, 0x48, 0x48,
+    0x50, 0xff, 0x64, 0x00, 0x2d, 0x00, 0x01, 0x43, 0x72, 0x65, 0x61, 0x74,
+    0x6f, 0x72, 0x3a, 0x20, 0x41, 0x56, 0x2d, 0x4a, 0x32, 0x4b, 0x20, 0x28,
+    0x01, 0x00, 0x80, 0x56, 0x61, 0x74, 0x6f, 0x72, 0x3a, 0x20, 0x41, 0x56,
+    0x2d, 0x4a, 0x32, 0x4b, 0x20, 0x28, 0x63, 0x29, 0x20, 0x69, 0x6f, 0x74,
+    0xff, 0x90, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x01,
+    0xff, 0x93, 0xff, 0xff, 0x4f, 0xff, 0x51
+};
+
+static void test_error_callback(const char *msg, void *user_data)
+{
+    (void)msg;
+    (void)user_data;
+}
+
+static void test_warning_callback(const char *msg, void *user_data)
+{
+    (void)msg;
+    (void)user_data;
+}
+
+static void test_info_callback(const char *msg, void *user_data)
+{
+    (void)msg;
+    (void)user_data;
+}
+
+static OPJ_SIZE_T test_read_callback(void* p_buffer, OPJ_SIZE_T p_nb_bytes,
+                                     void *p_user_data)
+{
+    test_mem_stream_t* mem_stream = (test_mem_stream_t*)p_user_data;
+    OPJ_SIZE_T bytes_to_read = p_nb_bytes;
+
+    if (mem_stream->offset >= mem_stream->data_len || p_nb_bytes == 0U) {
+        return (OPJ_SIZE_T)-1;
+    }
+
+    if (mem_stream->offset + p_nb_bytes > mem_stream->data_len) {
+        bytes_to_read = mem_stream->data_len - mem_stream->offset;
+    }
+
+    memcpy(p_buffer, mem_stream->data + mem_stream->offset, bytes_to_read);
+    mem_stream->offset += bytes_to_read;
+    return bytes_to_read;
+}
+
+static OPJ_OFF_T test_skip_callback(OPJ_OFF_T p_nb_bytes, void *p_user_data)
+{
+    test_mem_stream_t* mem_stream = (test_mem_stream_t*)p_user_data;
+
+    mem_stream->offset += (OPJ_SIZE_T)p_nb_bytes;
+    return p_nb_bytes;
+}
+
+static OPJ_BOOL test_seek_callback(OPJ_OFF_T p_nb_bytes, void * p_user_data)
+{
+    test_mem_stream_t* mem_stream = (test_mem_stream_t*)p_user_data;
+
+    mem_stream->offset = (OPJ_SIZE_T)p_nb_bytes;
+    return OPJ_TRUE;
+}
+
+int main(void)
+{
+    test_mem_stream_t mem_stream;
+    opj_stream_t *stream = NULL;
+    opj_codec_t *codec = NULL;
+    opj_image_t *image = NULL;
+    opj_dparameters_t parameters;
+
+    mem_stream.data = issue1472_noeph;
+    mem_stream.data_len = sizeof(issue1472_noeph);
+    mem_stream.offset = 0U;
+
+    stream = opj_stream_create(1024, OPJ_TRUE);
+    if (stream == NULL) {
+        fprintf(stderr, "Failed to create input stream\n");
+        return 1;
+    }
+
+    opj_stream_set_user_data(stream, &mem_stream, NULL);
+    opj_stream_set_user_data_length(stream, sizeof(issue1472_noeph));
+    opj_stream_set_read_function(stream, test_read_callback);
+    opj_stream_set_skip_function(stream, test_skip_callback);
+    opj_stream_set_seek_function(stream, test_seek_callback);
+
+    codec = opj_create_decompress(OPJ_CODEC_J2K);
+    if (codec == NULL) {
+        fprintf(stderr, "Failed to create decoder\n");
+        opj_stream_destroy(stream);
+        return 1;
+    }
+
+    opj_set_info_handler(codec, test_info_callback, NULL);
+    opj_set_warning_handler(codec, test_warning_callback, NULL);
+    opj_set_error_handler(codec, test_error_callback, NULL);
+
+    opj_set_default_decoder_parameters(&parameters);
+    if (!opj_setup_decoder(codec, &parameters)) {
+        fprintf(stderr, "Failed to setup decoder\n");
+        opj_destroy_codec(codec);
+        opj_stream_destroy(stream);
+        return 1;
+    }
+
+    if (!opj_read_header(stream, codec, &image)) {
+        fprintf(stderr, "Expected the malformed codestream to reach packet decoding\n");
+        opj_destroy_codec(codec);
+        opj_stream_destroy(stream);
+        opj_image_destroy(image);
+        return 1;
+    }
+
+    if (opj_decode(codec, stream, image)) {
+        fprintf(stderr, "Malformed codestream unexpectedly decoded successfully\n");
+        opj_destroy_codec(codec);
+        opj_stream_destroy(stream);
+        opj_image_destroy(image);
+        return 1;
+    }
+
+    opj_destroy_codec(codec);
+    opj_stream_destroy(stream);
+    opj_image_destroy(image);
+    return 0;
+}

--- a/tests/unit/testissue1472_noeph.c
+++ b/tests/unit/testissue1472_noeph.c
@@ -85,6 +85,12 @@ static OPJ_BOOL test_seek_callback(OPJ_OFF_T p_nb_bytes, void * p_user_data)
     return OPJ_TRUE;
 }
 
+static void test_set_scod(OPJ_BYTE *dst, OPJ_BYTE scod)
+{
+    memcpy(dst, issue1472_noeph, sizeof(issue1472_noeph));
+    dst[ISSUE1472_SCOD_OFFSET] = scod;
+}
+
 static test_decode_result_t test_decode_codestream(const OPJ_BYTE *data,
         OPJ_SIZE_T data_len)
 {
@@ -142,6 +148,7 @@ cleanup:
 int main(void)
 {
     OPJ_BYTE issue1472_prt_only[sizeof(issue1472_noeph)];
+    OPJ_BYTE issue1472_eph_required[sizeof(issue1472_noeph)];
     test_decode_result_t result;
 
     result = test_decode_codestream(issue1472_noeph, sizeof(issue1472_noeph));
@@ -150,12 +157,20 @@ int main(void)
         return 1;
     }
 
-    memcpy(issue1472_prt_only, issue1472_noeph, sizeof(issue1472_prt_only));
-    issue1472_prt_only[ISSUE1472_SCOD_OFFSET] = 0x01;
+    test_set_scod(issue1472_prt_only, 0x01);
 
     result = test_decode_codestream(issue1472_prt_only, sizeof(issue1472_prt_only));
-    if (result == TEST_DECODE_HEADER_FAILURE) {
-        fprintf(stderr, "Expected the PRT-only variant to reach packet decoding\n");
+    if (result != TEST_DECODE_FAILURE) {
+        fprintf(stderr, "PRT-only malformed codestream unexpectedly avoided decode failure\n");
+        return 1;
+    }
+
+    test_set_scod(issue1472_eph_required, 0x07);
+
+    result = test_decode_codestream(issue1472_eph_required,
+                                    sizeof(issue1472_eph_required));
+    if (result != TEST_DECODE_FAILURE) {
+        fprintf(stderr, "EPH-required malformed codestream unexpectedly avoided decode failure\n");
         return 1;
     }
 

--- a/tests/unit/testissue1472_noeph.c
+++ b/tests/unit/testissue1472_noeph.c
@@ -4,12 +4,6 @@
 
 #include "openjpeg.h"
 
-typedef struct {
-    const OPJ_BYTE* data;
-    OPJ_SIZE_T data_len;
-    OPJ_SIZE_T offset;
-} test_mem_stream_t;
-
 typedef enum {
     TEST_DECODE_HEADER_FAILURE = -1,
     TEST_DECODE_FAILURE = 0,
@@ -18,6 +12,8 @@ typedef enum {
 
 #define ISSUE1472_SCOD_OFFSET 52
 #define TEST_CSTY_SOP 0x02
+
+#define TEST_TMP_FILENAME "testissue1472_noeph_tmp.bin"
 
 static const OPJ_BYTE issue1472_noeph[] = {
     0xff, 0x4f, 0xff, 0x51, 0x00, 0x2c, 0x00, 0x02, 0x04, 0x00, 0x00, 0x64,
@@ -34,99 +30,49 @@ static const OPJ_BYTE issue1472_noeph[] = {
     0xff, 0x93, 0xff, 0xff, 0x4f, 0xff, 0x51
 };
 
-static void test_error_callback(const char *msg, void *user_data)
+static void test_quiet_callback(const char *msg, void *user_data)
 {
     (void)msg;
     (void)user_data;
-}
-
-static void test_warning_callback(const char *msg, void *user_data)
-{
-    (void)msg;
-    (void)user_data;
-}
-
-static void test_info_callback(const char *msg, void *user_data)
-{
-    (void)msg;
-    (void)user_data;
-}
-
-static OPJ_SIZE_T test_read_callback(void* p_buffer, OPJ_SIZE_T p_nb_bytes,
-                                     void *p_user_data)
-{
-    test_mem_stream_t* mem_stream = (test_mem_stream_t*)p_user_data;
-    OPJ_SIZE_T bytes_to_read = p_nb_bytes;
-
-    if (mem_stream->offset >= mem_stream->data_len || p_nb_bytes == 0U) {
-        return (OPJ_SIZE_T)-1;
-    }
-
-    if (mem_stream->offset + p_nb_bytes > mem_stream->data_len) {
-        bytes_to_read = mem_stream->data_len - mem_stream->offset;
-    }
-
-    memcpy(p_buffer, mem_stream->data + mem_stream->offset, bytes_to_read);
-    mem_stream->offset += bytes_to_read;
-    return bytes_to_read;
-}
-
-static OPJ_OFF_T test_skip_callback(OPJ_OFF_T p_nb_bytes, void *p_user_data)
-{
-    test_mem_stream_t* mem_stream = (test_mem_stream_t*)p_user_data;
-
-    mem_stream->offset += (OPJ_SIZE_T)p_nb_bytes;
-    return p_nb_bytes;
-}
-
-static OPJ_BOOL test_seek_callback(OPJ_OFF_T p_nb_bytes, void * p_user_data)
-{
-    test_mem_stream_t* mem_stream = (test_mem_stream_t*)p_user_data;
-
-    mem_stream->offset = (OPJ_SIZE_T)p_nb_bytes;
-    return OPJ_TRUE;
-}
-
-static void test_set_scod(OPJ_BYTE *dst, OPJ_BYTE scod)
-{
-    memcpy(dst, issue1472_noeph, sizeof(issue1472_noeph));
-    dst[ISSUE1472_SCOD_OFFSET] = scod;
 }
 
 static test_decode_result_t test_decode_codestream(const OPJ_BYTE *data,
         OPJ_SIZE_T data_len, OPJ_CODEC_FORMAT codec_format)
 {
-    test_mem_stream_t mem_stream;
     opj_stream_t *stream = NULL;
     opj_codec_t *codec = NULL;
     opj_image_t *image = NULL;
     opj_dparameters_t parameters;
+    FILE *fp;
     test_decode_result_t result = TEST_DECODE_HEADER_FAILURE;
 
-    mem_stream.data = data;
-    mem_stream.data_len = data_len;
-    mem_stream.offset = 0U;
-
-    stream = opj_stream_create(1024, OPJ_TRUE);
-    if (stream == NULL) {
+    fp = fopen(TEST_TMP_FILENAME, "wb");
+    if (fp == NULL) {
         return TEST_DECODE_HEADER_FAILURE;
     }
+    if (fwrite(data, 1U, data_len, fp) != data_len) {
+        fclose(fp);
+        remove(TEST_TMP_FILENAME);
+        return TEST_DECODE_HEADER_FAILURE;
+    }
+    fclose(fp);
 
-    opj_stream_set_user_data(stream, &mem_stream, NULL);
-    opj_stream_set_user_data_length(stream, data_len);
-    opj_stream_set_read_function(stream, test_read_callback);
-    opj_stream_set_skip_function(stream, test_skip_callback);
-    opj_stream_set_seek_function(stream, test_seek_callback);
+    stream = opj_stream_create_default_file_stream(TEST_TMP_FILENAME, OPJ_TRUE);
+    if (stream == NULL) {
+        remove(TEST_TMP_FILENAME);
+        return TEST_DECODE_HEADER_FAILURE;
+    }
 
     codec = opj_create_decompress(codec_format);
     if (codec == NULL) {
         opj_stream_destroy(stream);
+        remove(TEST_TMP_FILENAME);
         return TEST_DECODE_HEADER_FAILURE;
     }
 
-    opj_set_info_handler(codec, test_info_callback, NULL);
-    opj_set_warning_handler(codec, test_warning_callback, NULL);
-    opj_set_error_handler(codec, test_error_callback, NULL);
+    opj_set_info_handler(codec, test_quiet_callback, NULL);
+    opj_set_warning_handler(codec, test_quiet_callback, NULL);
+    opj_set_error_handler(codec, test_quiet_callback, NULL);
 
     opj_set_default_decoder_parameters(&parameters);
     if (!opj_setup_decoder(codec, &parameters)) {
@@ -144,6 +90,7 @@ cleanup:
     opj_destroy_codec(codec);
     opj_stream_destroy(stream);
     opj_image_destroy(image);
+    remove(TEST_TMP_FILENAME);
     return result;
 }
 
@@ -191,11 +138,21 @@ static OPJ_BYTE *test_read_file(const char *filename, OPJ_SIZE_T *data_len)
     return data;
 }
 
+/* Set the SOP bit in the Scod byte of the first COD marker of the
+ * codestream. The search is anchored at the SOC marker so that incidental
+ * 0xff 0x52 byte pairs in JP2 wrapper boxes cannot be patched by mistake. */
 static OPJ_BOOL test_enable_sop_csty(OPJ_BYTE *data, OPJ_SIZE_T data_len)
 {
     OPJ_SIZE_T offset;
+    OPJ_BOOL soc_found = OPJ_FALSE;
 
     for (offset = 0U; offset + 4U < data_len; ++offset) {
+        if (!soc_found) {
+            if (data[offset] == 0xffU && data[offset + 1U] == 0x4fU) {
+                soc_found = OPJ_TRUE;
+            }
+            continue;
+        }
         if (data[offset] == 0xffU && data[offset + 1U] == 0x52U) {
             data[offset + 4U] |= TEST_CSTY_SOP;
             return OPJ_TRUE;
@@ -266,33 +223,34 @@ static int test_sop_optional_tolerated_eof(const char *data_root)
 
 int main(int argc, char **argv)
 {
-    OPJ_BYTE issue1472_prt_only[sizeof(issue1472_noeph)];
-    OPJ_BYTE issue1472_eph_required[sizeof(issue1472_noeph)];
-    test_decode_result_t result;
+    /* The embedded codestream carries Scod = 0x03 (PRT+SOP) at offset 52;
+     * the other entries derive the PRT-only and PRT+SOP+EPH variants. */
+    static const struct {
+        OPJ_BYTE scod;
+        const char *description;
+    } malformed_variants[] = {
+        { 0x03, "no-EPH (PRT+SOP)" },
+        { 0x01, "PRT-only" },
+        { 0x07, "EPH-required (PRT+SOP+EPH)" }
+    };
+    OPJ_BYTE codestream[sizeof(issue1472_noeph)];
+    size_t i;
 
-    result = test_decode_codestream(issue1472_noeph, sizeof(issue1472_noeph),
-                                    OPJ_CODEC_J2K);
-    if (result != TEST_DECODE_FAILURE) {
-        fprintf(stderr, "Malformed no-EPH codestream unexpectedly avoided decode failure\n");
-        return 1;
-    }
+    for (i = 0U; i < sizeof(malformed_variants) / sizeof(malformed_variants[0]);
+            ++i) {
+        test_decode_result_t result;
 
-    test_set_scod(issue1472_prt_only, 0x01);
+        memcpy(codestream, issue1472_noeph, sizeof(issue1472_noeph));
+        codestream[ISSUE1472_SCOD_OFFSET] = malformed_variants[i].scod;
 
-    result = test_decode_codestream(issue1472_prt_only, sizeof(issue1472_prt_only),
-                                    OPJ_CODEC_J2K);
-    if (result != TEST_DECODE_FAILURE) {
-        fprintf(stderr, "PRT-only malformed codestream unexpectedly avoided decode failure\n");
-        return 1;
-    }
-
-    test_set_scod(issue1472_eph_required, 0x07);
-
-    result = test_decode_codestream(issue1472_eph_required,
-                                    sizeof(issue1472_eph_required), OPJ_CODEC_J2K);
-    if (result != TEST_DECODE_FAILURE) {
-        fprintf(stderr, "EPH-required malformed codestream unexpectedly avoided decode failure\n");
-        return 1;
+        result = test_decode_codestream(codestream, sizeof(codestream),
+                                        OPJ_CODEC_J2K);
+        if (result != TEST_DECODE_FAILURE) {
+            fprintf(stderr,
+                    "%s malformed codestream unexpectedly avoided decode failure\n",
+                    malformed_variants[i].description);
+            return 1;
+        }
     }
 
     return test_sop_optional_tolerated_eof(argc > 1 ? argv[1] : NULL);


### PR DESCRIPTION
Addresses CVE-2023-39327.

PR #1547 requires EPH markers and fixes the exact `issue1472` PoC, but malformed variants derived from the same codestream can still reach the empty-packet path with zero forward progress. With `Scod = 0x03` (`PRT+SOP`), the decoder loops printing `Not enough space for expected SOP marker`. With `Scod = 0x01` (`PRT` only), it can spend excessive time walking packet iteration after EOF.

The root cause is that `opj_t2_read_packet_header()` can still report a successful empty packet after consuming zero bytes. When that happens, the caller keeps iterating packets against unchanged input.

This change makes packet progression explicit in the T2 decode path. A zero-progress empty-packet header is treated as packet-header exhaustion instead of a successful packet, and the decoder finalizes `resno_decoded` the same way the tolerant EOF path would have ended before stopping packet iteration. This stops the malformed inputs promptly while preserving tolerated truncated decodes, including codestreams where SOP markers are allowed by `Scod` but absent.

It also expands the focused unit coverage to exercise three nearby malformed variants derived from the same in-memory codestream:

- `Scod = 0x03` (`PRT+SOP`)
- `Scod = 0x01` (`PRT` only)
- `Scod = 0x07` (`PRT+SOP+EPH`)

The unit test also covers a tolerated EOF fixture from `openjpeg-data` after setting the SOP bit in `Scod` without adding SOP markers, so optional SOP absence remains non-fatal.

To keep the same-CVE fuzz follow-up in this PR, `tests/fuzzers/build_seed_corpus.sh` now derives the `0x03` and `0x01` `issue1472` variants from the existing upstream `issue1472-bigloop.j2k` seed when building `opj_decompress_fuzzer_seed_corpus.zip`. The script verifies the source seed still has the expected `Scod = 0x07` byte before mutating it.

## Testing

- Built `opj_decompress` and `testissue1472_noeph`
- Ran `ctest -R "^testissue1472_noeph$" --output-on-failure`
- Reproduced the malformed `Scod = 0x07` variant: it fails quickly with `Not enough space for required EPH marker`
- Reproduced the malformed `Scod = 0x03` variant: it returns promptly with `Stream too short, expected SOT`
- Reproduced the malformed `Scod = 0x01` variant: it returns promptly with `Stream too short, expected SOT`
- Rechecked the previously regressed nonregression inputs locally:
  - `Marrin.jp2`
  - `dwt_interleave_h.gsr105.jp2`
  - `dwt_interleave_h.gsr105.jp2 -d 1,1,33,33`
  - `issue226.j2k` (same local baseline failure as `master`)
- Rechecked SOP-bit/no-SOP tolerated EOF variants of:
  - `Marrin.jp2`
  - `dwt_interleave_h.gsr105.jp2`
- Ran `tests/fuzzers/build_seed_corpus.sh` against the standard `openjpeg-data` checkout and confirmed `opj_decompress_fuzzer_seed_corpus.zip` contains:
  - `issue1472-bigloop.j2k`
  - `issue1472-bigloop-noeph.j2k`
  - `issue1472-bigloop-prt-only.j2k`
