### PR TITLE
Fix a few warnings

### DIFF
--- a/src/lib/openjp2/mqc.c
+++ b/src/lib/openjp2/mqc.c
@@ -370,11 +370,6 @@ void opj_mqc_erterm_enc(opj_mqc_t *mqc)
     }
 }
 
-static INLINE void opj_mqc_renorme(opj_mqc_t *mqc)
-{
-    opj_mqc_renorme_macro(mqc, mqc->a, mqc->c, mqc->ct);
-}
-
 /**
 Encode the most probable symbol
 @param mqc MQC handle

--- a/src/lib/openjp2/pi.c
+++ b/src/lib/openjp2/pi.c
@@ -1630,7 +1630,6 @@ opj_pi_iterator_t *opj_pi_initialise_encode(const opj_image_t *p_image,
     /* pointers*/
     opj_pi_iterator_t *l_pi = 00;
     opj_tcp_t *l_tcp = 00;
-    const opj_tccp_t *l_tccp = 00;
     opj_pi_comp_t *l_current_comp = 00;
     opj_image_comp_t * l_img_comp = 00;
     opj_pi_iterator_t * l_current_pi = 00;
@@ -1705,7 +1704,6 @@ opj_pi_iterator_t *opj_pi_initialise_encode(const opj_image_t *p_image,
     /* special treatment for the first packet iterator*/
     l_current_comp = l_current_pi->comps;
     l_img_comp = p_image->comps;
-    l_tccp = l_tcp->tccps;
     l_current_pi->tx0 = l_tx0;
     l_current_pi->ty0 = l_ty0;
     l_current_pi->tx1 = l_tx1;
@@ -1736,14 +1734,12 @@ opj_pi_iterator_t *opj_pi_initialise_encode(const opj_image_t *p_image,
 
         ++l_current_comp;
         ++l_img_comp;
-        ++l_tccp;
     }
     ++l_current_pi;
 
     for (pino = 1 ; pino < l_bound ; ++pino) {
         l_current_comp = l_current_pi->comps;
         l_img_comp = p_image->comps;
-        l_tccp = l_tcp->tccps;
 
         l_current_pi->tx0 = l_tx0;
         l_current_pi->ty0 = l_ty0;
@@ -1773,7 +1769,6 @@ opj_pi_iterator_t *opj_pi_initialise_encode(const opj_image_t *p_image,
             }
             ++l_current_comp;
             ++l_img_comp;
-            ++l_tccp;
         }
 
         /* special treatment*/

--- a/src/lib/openjp2/pi.c
+++ b/src/lib/openjp2/pi.c
@@ -1412,7 +1412,6 @@ opj_pi_iterator_t *opj_pi_create_decode(opj_image_t *p_image,
     /* pointers */
     opj_pi_iterator_t *l_pi = 00;
     opj_tcp_t *l_tcp = 00;
-    const opj_tccp_t *l_tccp = 00;
     opj_pi_comp_t *l_current_comp = 00;
     opj_image_comp_t * l_img_comp = 00;
     opj_pi_iterator_t * l_current_pi = 00;
@@ -1490,7 +1489,6 @@ opj_pi_iterator_t *opj_pi_create_decode(opj_image_t *p_image,
     /* special treatment for the first packet iterator */
     l_current_comp = l_current_pi->comps;
     l_img_comp = p_image->comps;
-    l_tccp = l_tcp->tccps;
 
     l_current_pi->tx0 = l_tx0;
     l_current_pi->ty0 = l_ty0;
@@ -1524,14 +1522,12 @@ opj_pi_iterator_t *opj_pi_create_decode(opj_image_t *p_image,
         }
         ++l_current_comp;
         ++l_img_comp;
-        ++l_tccp;
     }
     ++l_current_pi;
 
     for (pino = 1 ; pino < l_bound ; ++pino) {
         l_current_comp = l_current_pi->comps;
         l_img_comp = p_image->comps;
-        l_tccp = l_tcp->tccps;
 
         l_current_pi->tx0 = l_tx0;
         l_current_pi->ty0 = l_ty0;
@@ -1563,7 +1559,6 @@ opj_pi_iterator_t *opj_pi_create_decode(opj_image_t *p_image,
             }
             ++l_current_comp;
             ++l_img_comp;
-            ++l_tccp;
         }
         /* special treatment*/
         l_current_pi->include = (l_current_pi - 1)->include;

--- a/src/lib/openjp2/tcd.c
+++ b/src/lib/openjp2/tcd.c
@@ -2471,7 +2471,6 @@ static OPJ_BOOL opj_tcd_dc_level_shift_encode(opj_tcd_t *p_tcd)
     OPJ_UINT32 compno;
     opj_tcd_tilecomp_t * l_tile_comp = 00;
     opj_tccp_t * l_tccp = 00;
-    opj_image_comp_t * l_img_comp = 00;
     opj_tcd_tile_t * l_tile;
     OPJ_SIZE_T l_nb_elem, i;
     OPJ_INT32 * l_current_ptr;
@@ -2479,7 +2478,6 @@ static OPJ_BOOL opj_tcd_dc_level_shift_encode(opj_tcd_t *p_tcd)
     l_tile = p_tcd->tcd_image->tiles;
     l_tile_comp = l_tile->comps;
     l_tccp = p_tcd->tcp->tccps;
-    l_img_comp = p_tcd->image->comps;
 
     for (compno = 0; compno < l_tile->numcomps; compno++) {
         l_current_ptr = l_tile_comp->data;
@@ -2499,7 +2497,6 @@ static OPJ_BOOL opj_tcd_dc_level_shift_encode(opj_tcd_t *p_tcd)
             }
         }
 
-        ++l_img_comp;
         ++l_tccp;
         ++l_tile_comp;
     }


### PR DESCRIPTION
With this, things build without warnings for me (macOX, Xcode 26.2) when using
CMAKE_C_FLAGS="-Wall -Wextra -Wconversion -Wno-unused-parameter -Wdeclaration-after-statement -Werror=declaration-after-statement"

Per https://github.com/uclouvain/openjpeg/pull/1629#issuecomment-4309230241, those are the warnings used on CI.

No intended behavior change.