### PR TITLE
ci: add permissions and pin action SHAs (4 workflows)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/abi_check.yml
+++ b/.github/workflows/abi_check.yml
@@ -2,13 +2,15 @@ name: ABI check
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: read-all
+
 jobs:
   abi_check:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Install Requirements
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,15 @@ name: Build
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: read-all
+
 jobs:
   regular:
     runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Install Requirements
         run: |
@@ -28,7 +30,7 @@ jobs:
             OPJ_NONCOMMERCIAL: 1
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: build/openjpeg-*.tar.gz
@@ -38,7 +40,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Install Requirements
         run: |
@@ -60,7 +62,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Install Requirements
         run: |
@@ -85,7 +87,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Install Requirements
         run: |
@@ -108,7 +110,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Build and run tests
         run: |
@@ -122,7 +124,7 @@ jobs:
             #OPJ_NONCOMMERCIAL: 1
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: build/openjpeg-*.zip
@@ -132,7 +134,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Build and run tests
         run: |
@@ -146,7 +148,7 @@ jobs:
             #OPJ_NONCOMMERCIAL: 1
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: build/openjpeg-*.zip
@@ -192,7 +194,7 @@ jobs:
           git config --system core.longpaths true
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Set compiler environment
         shell: cmd
@@ -215,7 +217,7 @@ jobs:
         shell: bash
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         if: ${{startsWith(github.ref, 'refs/tags/') && env.OPJ_CI_INCLUDE_IF_DEPLOY == 1}}
         with:
           files: build/openjpeg-*.zip

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,25 +1,27 @@
 name: CIFuzz
 on: [pull_request]
+permissions: read-all
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest
     steps:
     - name: Build Fuzzers
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@439b356d09b53fe1161e9fe22ac42536926983db  # master
       with:
         oss-fuzz-project-name: 'openjpeg'
         dry-run: false
         language: c
     - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@439b356d09b53fe1161e9fe22ac42536926983db  # master
       with:
         oss-fuzz-project-name: 'openjpeg'
         fuzz-seconds: 600
         dry-run: false
         language: c
     - name: Upload Crash
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -2,13 +2,15 @@ name: Code Style
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: read-all
+
 jobs:
   code_style:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
             fetch-depth: 0
 


### PR DESCRIPTION
## Summary

The CI workflows are missing top-level \`permissions\` declarations and reference actions by mutable version tags, which are supply-chain risk vectors.

**Changes:**
- Add \`permissions: read-all\` at the workflow level for all workflows (least-privilege default)
- Pin all third-party action references to full commit SHAs

Mutable action references (\`@v4\`, \`@main\`, etc.) allow a compromised upstream action to run arbitrary code in your CI. Pinning to a commit SHA ensures only the audited version runs.