### PR TITLE
Fix data loss / assert when encoding tiles with empty resolution levels

### DIFF
--- a/src/lib/openjp2/dwt.c
+++ b/src/lib/openjp2/dwt.c
@@ -1361,7 +1361,7 @@ void opj_dwt_encode_and_deinterleave_h_one_row(void* rowIn,
     } else {
         if (width == 1) {
             row[0] *= 2;
-        } else {
+        } else if (width > 1) {
             OPJ_INT32 i;
             tmp[sn + 0] = row[0] - row[1];
             for (i = 1; i < sn; i++) {
@@ -1393,7 +1393,7 @@ void opj_dwt_encode_and_deinterleave_h_one_row_real(void* rowIn,
     OPJ_FLOAT32* OPJ_RESTRICT tmp = (OPJ_FLOAT32*)tmpIn;
     const OPJ_INT32 sn = (OPJ_INT32)((width + (even ? 1 : 0)) >> 1);
     const OPJ_INT32 dn = (OPJ_INT32)(width - (OPJ_UINT32)sn);
-    if (width == 1) {
+    if (width <= 1) {
         return;
     }
     memcpy(tmp, row, width * sizeof(OPJ_FLOAT32));


### PR DESCRIPTION
When a tile is narrow but the number of decomposition levels is large, some of its lower resolution levels can become empty. Neither 5/3 not 9/7 DWT handled zero-length inputs correctly:

- opj_dwt_encode_and_deinterleave_h_one_row (5/3, lossless): The `if (even)` branch correctly checks `if (width > 1)`, but the else branch for the odd case special-cased `width == 1` and then just had an `else` branch on that. This caused width == 0 to be handled incorrectly. This is similar to the `if (even)` branch just above, and also similar to inverse opj_idwt53_h with its `if (len > 1)`. Fixes #1575.

- opj_dwt_encode_and_deinterleave_h_one_row_real (9/7, lossy): only returned early for width == 1, so for width == 0 it called opj_dwt_encode_1_real() with dn == sn == 0. This tripped the `assert(dn + sn > 1)` therein in debug builds. Return early for `width <= 1`, to handle empty tiles too.

Before this commit, reproduced with a 119x53 grayscale image: width 119 with `-t 117` leaves a 2-pixel-wide right edge tile, and `-n 5` makes that tile's three lowest resolution levels empty:

    # lossless: cols 117-118 corrupted
    opj_compress -i in.pgm -o out.jp2 -n 5 -t 117,53

    # lossy: assert abort in debug builds
    opj_compress -i in.pgm -o out.jp2 -n 5 -t 117,53 -I